### PR TITLE
Update querystinghock using different method for declaring instance type

### DIFF
--- a/src/hock/QueryStringHock.jsx
+++ b/src/hock/QueryStringHock.jsx
@@ -75,15 +75,14 @@ const QueryStringHock = (config: ?Object = null, onQueryChangeFunction: ?Functio
 
         class QueryStringHock extends Component {
 
-            updateQuery: Function;
-            setQuery: Function;
-
             constructor(props) {
                 super(props);
 
+                const instance: any = this;
+
                 // explicit bind until es7
-                this.updateQuery = this.updateQuery.bind(this);
-                this.setQuery = this.setQuery.bind(this);
+                instance.updateQuery = instance.updateQuery.bind(instance);
+                instance.setQuery = instance.setQuery.bind(instance);
             }
 
             /**


### PR DESCRIPTION
I don't love the syntax but it fixes both the build and the flow errors...

@allanhortle @dxinteractive what do you think?