### PR TITLE
Add docs and example deployment to gh-pages script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ docs
 lib
 .nyc_output
 coverage
+yarn-error.log
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 The new and improved stampy.
 
-
+- [API Documentation](https://bigdatr.github.io/stampy/docs)
+- [Examples](https://bigdatr.github.io/stampy/example)
 
 ## Contributing
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,7 @@
+general:
+  branches:
+    ignore:
+      - gh-pages
 machine:
     pre:
         - mkdir ~/.yarn-cache
@@ -18,3 +22,9 @@ dependencies:
 test:
     override:
         - yarn run test-all
+deployment:
+    master:
+        branch: master
+        owner: bigdatr
+        commands:
+            - yarn run deploy-to-gh-pages

--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title></title>
+</head>
+<body>
+    <ul>
+        <li><a href="./docs">Documentation</a></li>
+        <li><a href="./example">Examples</a></li>
+    </ul>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "dev": "babel src -d lib --watch",
     "build": "rm -rf lib && babel src --out-dir lib && yarn run css",
-    "prepublish": "babel src --out-dir lib",
+    "prepublish": "yarn run build",
     "lint": "eslint src/**/*.jsx src/**/*.js",
     "lint-fix": "eslint src/**/*.jsx src/**/*.js --fix",
     "ava": "ava",
@@ -18,7 +18,6 @@
     "test-all": "yarn run lint && yarn run flow && yarn run test",
     "check-coverage": "nyc check-coverage --branches 0.0  --functions 0.0 --lines 0",
     "docs": "jsdoc -c jsdoc-config.json",
-    "publish-docs": "yarn run docs && gh-pages --dist docs",
     "build-examples": "cd example && yarn install && yarn run build && cd -",
     "flow": "flow; test $? -eq 0 -o $? -eq 2",
     "css-base-combined": "sh scripts/css-base-combined.sh",
@@ -26,7 +25,8 @@
     "css-base": "sh scripts/css-base.sh",
     "css-default": "sh scripts/css-default.sh",
     "postcss": "postcss --use autoprefixer -r lib/**/*.css",
-    "css": "yarn run css-base-combined && yarn run css-default-combined && yarn run css-base && yarn run css-default && yarn run postcss"
+    "css": "yarn run css-base-combined && yarn run css-default-combined && yarn run css-base && yarn run css-default && yarn run postcss",
+    "deploy-to-gh-pages": "yarn run build && yarn run build-examples && yarn run docs && node scripts/publish.js"
   },
   "devDependencies": {
     "app-module-path": "^2.0.0",
@@ -48,7 +48,7 @@
     "git-url-parse": "^6.0.1",
     "jsdoc": "^3.4.2",
     "jsdoc-babel": "^0.2.1",
-    "jsdonk": "0.1.7",
+    "jsdonk": "0.2.1",
     "node-sass": "^3.11.2",
     "nyc": "^6.6.1",
     "postcss-cli": "^2.6.0",

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -1,0 +1,14 @@
+const ghpages = require('gh-pages');
+const path = require('path');
+
+ghpages.publish(path.resolve(__dirname, '../'), {
+    src: ['index.html', 'docs/**/*', 'example/dist/**/*', 'example/index.html'],
+    logger: function(message) {
+        console.log(message);
+    }
+}, function(err){
+    if(err) {
+        console.error(err);
+        process.exit(1);
+    }
+});


### PR DESCRIPTION
This should build and publish the docs and examples to github pages when merging into master.
