### PR TITLE
CSS cooking updates

### DIFF
--- a/example/src/sass/style.scss
+++ b/example/src/sass/style.scss
@@ -1,3 +1,5 @@
+@import '~stampy/lib/base';
+
 body, html {
     margin: 0;
     padding: 0;

--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -33,7 +33,8 @@ const development = {
     },
     resolve: {
         extensions: ['', '.jsx', '.js'],
-        modulesDirectories: ['src', 'node_modules'],
+        modulesDirectories: ['/fake-directory-dont-create-a-directory-here'],
+        root: [path.resolve(__dirname, './src'), path.resolve(__dirname, './node_modules')],
         alias: {
             stampy: path.resolve(__dirname, "../")
         }
@@ -55,6 +56,9 @@ const development = {
     },
     postcss : function() {
         return [autoprefixer({browsers : ['ie >= 9', 'last 2 versions']})]
+    },
+    sassLoader: {
+        includePaths: [path.resolve(__dirname, "node_modules")]
     },
     devServer : {
         host: '0.0.0.0',

--- a/scripts/css-base-combined.sh
+++ b/scripts/css-base-combined.sh
@@ -2,4 +2,4 @@
 mkdir -p lib &&                                                 \
 find src -name '*-base.scss' |                                  \
 xargs cat > lib/base.scss &&                                    \
-node-sass --output-style compact lib/base.scss lib/base.css
+node-sass --include-path node_modules --output-style compressed lib/base.scss lib/base.css

--- a/scripts/css-base.sh
+++ b/scripts/css-base.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 find src -name '*-base.scss' | while read -r FILE
-    do        
+    do
         mkdir -p $(echo $(dirname "$FILE") | sed -e 's/^src\//lib\//')
         cp "$FILE" $(echo "$FILE" | sed -e 's/^src\//lib\//')
-        node-sass --output-style compact "$FILE" $(echo "$FILE" | sed -e 's/^src\//lib\//' -e 's/\.scss$/\.css/')
+        node-sass --include-path node_modules --output-style compressed "$FILE" $(echo "$FILE" | sed -e 's/^src\//lib\//' -e 's/\.scss$/\.css/')
     done

--- a/scripts/css-default-combined.sh
+++ b/scripts/css-default-combined.sh
@@ -4,4 +4,4 @@ find src -name '*-base.scss' |                                          \
 xargs cat > lib/default.scss &&                                         \
 find src -name '*-default.scss' |                                       \
 xargs cat >> lib/default.scss &&                                        \
-node-sass --output-style compact lib/default.scss lib/default.css
+node-sass --include-path node_modules --output-style compressed lib/default.scss lib/default.css

--- a/scripts/css-default.sh
+++ b/scripts/css-default.sh
@@ -7,5 +7,5 @@ find src -name '*-default.scss' | while read -r FILE
         combined=$(cat $([ -r "$base" ] && echo "$base" ) $FILE)
 
         echo "$combined" > $(echo "$FILE" | sed -e 's/^src\//lib\//')
-        echo "$combined" | node-sass --output-style compact > $(echo "$FILE" | sed -e 's/^src\//lib\//' -e 's/\.scss$/\.css/')
+        echo "$combined" | node-sass --include-path node_modules --output-style compressed > $(echo "$FILE" | sed -e 's/^src\//lib\//' -e 's/\.scss$/\.css/')
     done

--- a/src/input/toggle/Toggle.jsx
+++ b/src/input/toggle/Toggle.jsx
@@ -2,7 +2,6 @@
 import React from 'react';
 import SpruceClassName from '../../util/SpruceClassName';
 import RemoveProps from '../../util/RemoveProps';
-import Button from '../../component/button/Button';
 
 type ToggleProps = {
     className: ?string,


### PR DESCRIPTION
- Pushing updates we got working for compiling component CSS
- Example webpack config now doesn't climb backward up the file tree when trying to find its modules
- Removed leftover Button import on Toggle