### PR TITLE
Allow classNames for tds and ths and custom th rendering for Table

### DIFF
--- a/src/component/table/Table-test.js
+++ b/src/component/table/Table-test.js
@@ -16,6 +16,15 @@ const schema = [
     },
     {
         value: 'baz'
+    },
+    {
+        heading: () => <th>Heading</th>,
+        value: 'wop'
+    },
+    {
+        heading: 'nok',
+        value: 'tol',
+        className: 'azt'
     }
 ];
 
@@ -23,12 +32,16 @@ const data = [
     {
         foo: 1,
         bar: 2,
-        baz: 3
+        baz: 3,
+        wop: 7,
+        tol: 9
     },
     {
         foo: 4,
         bar: 5,
-        baz: 6
+        baz: 6,
+        wop: 8,
+        tol: 10
     }
 ];
 
@@ -48,7 +61,9 @@ test('th content rendering', tt => {
             .render();
     };
 
-    tt.is(wrapper.find('Th').length, 3);
+    tt.is(wrapper.find('Th').length, 5);
+    tt.is(ThList(4).html(), '<th class="azt">nok</th>');
+    tt.is(ThList(3).text(), 'Heading');
     tt.is(ThList(2).text(), '');
     tt.is(ThList(1).text(), 'bar');
     tt.is(ThList(0).html(), '<th style="width:200px;">foo</th>');
@@ -71,4 +86,5 @@ test('td content rendering', tt => {
     tt.is(firstTd.attr('class'), 'test');
     tt.is(renderAt(firstRow, 'Td', 1).text(), '2|1');
     tt.is(renderAt(firstRow, 'Td', 2).text(), '3');
+    tt.is(renderAt(firstRow, 'Td', 4).html(), '<td class="azt">9</td>');
 });

--- a/src/component/table/Table.jsx
+++ b/src/component/table/Table.jsx
@@ -15,16 +15,21 @@ type ThProps = {
 }
 
 function Th(props: ThProps): React.Element<any> {
-    var {width, heading = ''} = props.schemaItem.toObject();
+    const {
+        width,
+        heading = '',
+        className
+    } = props.schemaItem.toObject();
 
     const content: any = (typeof heading === 'function')
         ? heading()
         : heading;
 
-    return <th
-        style={{width}}
-        children={content}
-    />;
+    // Only return a th if the schema hasn't
+    // provided one
+    return (content && content.type === 'th')
+        ? content
+        : <th className={className} style={{width}}>{content}</th>;
 }
 
 
@@ -38,7 +43,7 @@ type TdProps = {
 
 function Td(props: TdProps): React.Element<any> {
     const {row, schemaItem} = props;
-    const {render, value} = schemaItem.toObject();
+    const {render, value, className} = schemaItem.toObject();
 
     // Content rendering priority order
     // 1. render function
@@ -55,7 +60,7 @@ function Td(props: TdProps): React.Element<any> {
     // provided one
     return (content && content.type === 'td')
         ? content
-        : <td>{content}</td>;
+        : <td className={className}>{content}</td>;
 }
 
 
@@ -69,7 +74,7 @@ type SchemaItem = {
     value: string | (row: Map<any>) => React.Element<any>,
     heading: string | () => React.Element<any>,
     render: (row: Map<any>) => React.Element<any>,
-    width: string | number
+    width: string
 }
 
 type TableProps = {
@@ -107,7 +112,9 @@ type TableProps = {
  * const schema = [
  *      {
  *          heading: 'Name',
- *          value: 'name'
+ *          value: 'name',
+ *          width: '100px',
+ *          className: 'Name'
  *      },
  *      {
  *          heading: 'BMI',
@@ -117,7 +124,7 @@ type TableProps = {
  *          }
  *      },
  *      {
- *          heading: 'Avatar',
+ *          heading: () => <th>Avatar</th>,
  *          render: row => <img src={row.get('avatarUrl')} />
  *      }
  * ];


### PR DESCRIPTION
Changes

- Add the ability to set class names for columns in the table schema.
- Allow heading function in schema to return a `th` so that it is consistent with the render function allowing return of a `td`
- Added some tests for the new functionality