### PR TITLE
Add basic show hide

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -5,4 +5,3 @@ module.system.node.resolve_dirname=src
 
 [libs]
 src/typedef/
-node_modules/immutable-js/dist/immutable.js.flow

--- a/example/src/component/showHide/ShowHideExample.jsx
+++ b/example/src/component/showHide/ShowHideExample.jsx
@@ -1,0 +1,39 @@
+import React, {Component} from 'react';
+import {ShowHide, ShowHideStateful} from 'stampy';
+
+class ShowHideExample extends Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            selectValue: null,
+            multiSelectValue: null
+        };
+    }
+    render() {
+        function Click(props) {
+            return <div>Click Me {props.show ? '-' : '+'}</div>;
+        }
+
+        return <div>
+            <h2>Visible</h2>
+            <ShowHide show={true} toggle={Click} onClick={(data) => console.log('ShowHide: ', data)}>Hello!</ShowHide>
+            <hr/>
+
+            <h2>Hidden</h2>
+            <ShowHide show={false} toggle={Click} onClick={(data) => console.log('ShowHide: ', data)}>Hello!</ShowHide>
+            <hr/>
+
+            <h2>Stateful</h2>
+            <ShowHideStateful toggle={Click} defaultShow={true}>Hello!</ShowHideStateful>
+            <hr/>
+
+
+            <h2>Stateful Hock</h2>
+            <ShowHideStateful toggle={Click} initialState={{show: true}}>Hello!</ShowHideStateful>
+            <hr/>
+
+        </div>
+    }
+}
+
+export default ShowHideExample;

--- a/example/src/routes.jsx
+++ b/example/src/routes.jsx
@@ -7,10 +7,12 @@ import ContentsPage from 'components/ContentsPage';
 
 import ButtonExample from 'component/button/ButtonExample';
 import LabelExample from 'component/field/LabelExample';
+import ShowHideExample from 'component/ShowHide/ShowHideExample';
 import TableExample from 'component/table/TableExample';
+
+import InputExample from 'input/input/InputExample';
 import SelectExample from 'input/select/SelectExample';
 import ToggleExample from 'input/toggle/ToggleExample';
-import InputExample from 'input/input/InputExample';
 
 import ElementQueryHockExample from 'hock/ElementQueryHockExample';
 import ElementQueryHockStressTest from 'hock/ElementQueryHockStressTest';
@@ -21,14 +23,15 @@ import SpruceComponentExample from 'util/SpruceComponentExample';
 const routes = <Route component={AppHandler} path="/">
     <IndexRoute component={ContentsPage} />
     <Route path="component">
-        <Route path="Table" component={TableExample}/>
         <Route path="Button" component={ButtonExample}/>
         <Route path="Label" component={LabelExample}/>
+        <Route path="ShowHide" component={ShowHideExample}/>
+        <Route path="Table" component={TableExample}/>
     </Route>
     <Route path="input">
-        <Route path="Toggle" component={ToggleExample}/>
         <Route path="Input" component={InputExample}/>
         <Route path="Select" component={SelectExample}/>
+        <Route path="Toggle" component={ToggleExample}/>
     </Route>
     <Route path="util">
         <Route path="SpruceClassName" component={SpruceClassNameExample}/>

--- a/src/component/showHide/ShowHide-test.js
+++ b/src/component/showHide/ShowHide-test.js
@@ -1,0 +1,53 @@
+import test from 'ava';
+import React from 'react';
+import {shallow} from 'enzyme';
+import sinon from 'sinon';
+
+import ShowHide, {ShowHideStateful} from './ShowHide';
+
+
+const toggle = () => <div></div>;
+
+test('ShowHide will toggle props.show onClick', tt => {
+    const onClick = sinon.spy();
+    const showHide = shallow(<ShowHide show={false} onClick={onClick} toggle={toggle}/>);
+    showHide.find('.ShowHide_toggle').simulate('click');
+    tt.is(onClick.firstCall.args[0], true);
+});
+
+test('ShowHide will not break if onClick is not provided', tt => {
+    const showHide = shallow(<ShowHide show={false} toggle={toggle}/>);
+    showHide.find('.ShowHide_toggle').simulate('click');
+    tt.is(showHide.find('.ShowHide_children').length, 0);
+});
+
+test('ShowHide will show children based on props.show', tt => {
+    const show = shallow(<ShowHide show={true} toggle={toggle}/>);
+    const hide = shallow(<ShowHide show={false} toggle={toggle}/>);
+    tt.is(show.find('.ShowHide_children').length, 1);
+    tt.is(hide.find('.ShowHide_children').length, 0);
+});
+
+
+test('ShowHideStateful default visibility off defaultShow', tt => {
+    const show = shallow(<ShowHideStateful toggle={toggle} defaultShow={true}/>);
+    const hide = shallow(<ShowHideStateful toggle={toggle} />);
+    tt.is(show.state('show'), true);
+    tt.is(hide.state('show'), false);
+});
+
+
+test('ShowHideStateful will toggle visibility on toggle', tt => {
+    const showHide = shallow(<ShowHideStateful toggle={toggle} defaultShow={true}/>);
+    showHide.instance().toggle(false);
+    tt.is(showHide.state('show'), false);
+});
+
+
+test('ShowHideStateful will passthrough props.onClick', tt => {
+    const onClick = sinon.spy();
+    const showHide = shallow(<ShowHideStateful toggle={toggle} onClick={onClick}/>);
+    showHide.instance().toggle(false);
+    tt.is(onClick.firstCall.args[0], false);
+});
+

--- a/src/component/showHide/ShowHide.jsx
+++ b/src/component/showHide/ShowHide.jsx
@@ -1,13 +1,13 @@
 // @flow
-import React, {PropTypes} from 'react';
+import React, {PropTypes, Element} from 'react';
 import SpruceClassName from '../../util/SpruceClassName';
 
 type ShowHideProps = {
-    children: React.Element<any>,
-    className: ?string,
-    modifier: Modifier,
+    children: Element<any>,
+    className?: string,
+    modifier?: Modifier,
     onClick: (value: boolean) => void,
-    show: ?boolean,
+    show?: boolean,
     toggle: ReactClass<any>
 }
 
@@ -27,7 +27,7 @@ type ShowHideProps = {
  * </ShowHide>
  */
 
-function ShowHide(props: ShowHideProps): React.Element<any> {
+function ShowHide(props: ShowHideProps): Element<any> {
     const {
         children,
         className,
@@ -48,7 +48,7 @@ function ShowHide(props: ShowHideProps): React.Element<any> {
 ShowHide.propTypes = {
     className: PropTypes.string,
     modifier: PropTypes.string,
-    onChange: PropTypes.func,
+    onClick: PropTypes.func,
     show: PropTypes.bool,
     toggle: PropTypes.func.isRequired
 };
@@ -58,8 +58,6 @@ ShowHide.defaultProps = {
     show: false
 }
 
-export default ShowHide;
-
 
 /**
  * @component
@@ -68,16 +66,28 @@ export default ShowHide;
  *
  *
  * @example
- * return <ShowHide show={false} onChange={props.onChange} toggle={() => <div>Toggle Me!</div>}>
+ * return <ShowHide show={false} onClick={props.onClick} toggle={() => <div>Toggle Me!</div>}>
  *     <h1>Hello!</h1>
  * </ShowHide>
  */
 
-export class ShowHideStateful extends React.Component {
-    state: Object;
-    toggle: Function;
+type ShowHideStatefulProps = {
+    children: Element<any>,
+    className?: string,
+    defaultShow: boolean,
+    modifier?: Modifier,
+    onClick: (value: boolean) => void,
+    toggle: ReactClass<any>
+}
 
-    constructor(props: Object) {
+export class ShowHideStateful extends React.Component {
+    props: ShowHideStatefulProps;
+    state: {
+        show: boolean
+    };
+    toggle: (newState: boolean) => void;
+
+    constructor(props: ShowHideStatefulProps) {
         super(props);
         this.state = {
             show: props.defaultShow || false
@@ -92,15 +102,25 @@ export class ShowHideStateful extends React.Component {
             this.props.onClick(newState);
         }
     }
-    render(): React.Element<ShowHide> {
+    render(): Element<any> {
         const {show} = this.state;
-        return <ShowHide {...this.props} show={show} onClick={this.toggle}/>;
+
+        return <ShowHide
+            {...this.props}
+            show={show}
+            onClick={this.toggle}
+        />;
     }
 }
 
-ShowHideStateful.propTypes = Object.assign({}, ShowHide.propTypes, {
+ShowHideStateful.propTypes = {
+    className: PropTypes.string,
+    modifier: PropTypes.string,
+    onClick: PropTypes.func,
+    toggle: PropTypes.func.isRequired,
     // Default choice to show or hide the content
     defaultShow: PropTypes.bool
-});
+};
 
+export default ShowHide;
 

--- a/src/component/showHide/ShowHide.jsx
+++ b/src/component/showHide/ShowHide.jsx
@@ -1,0 +1,106 @@
+// @flow
+import React, {PropTypes} from 'react';
+import SpruceClassName from '../../util/SpruceClassName';
+
+type ShowHideProps = {
+    children: React.Element<any>,
+    className: ?string,
+    modifier: Modifier,
+    onClick: (value: boolean) => void,
+    show: ?boolean,
+    toggle: ReactClass<any>
+}
+
+/**
+ * @module Components
+ */
+
+/**
+ * @component
+ *
+ * `ShowHide` is a controlled component that displays children based on the value of `props.show`.
+ * It does not keep state but provides an onChange function toggle `props.show`.
+ *
+ * @example
+ * return <ShowHide show={false} onChange={props.onChange} toggle={() => <div>Toggle Me!</div>}>
+ *     <h1>Hello!</h1>
+ * </ShowHide>
+ */
+
+function ShowHide(props: ShowHideProps): React.Element<any> {
+    const {
+        children,
+        className,
+        modifier,
+        onClick,
+        show,
+        toggle: Toggle
+    } = props;
+
+    return <div className={SpruceClassName({name: 'ShowHide', modifier, className})}>
+        <div className="ShowHide_toggle" onClick={() => onClick(!show)}>
+            <Toggle value={show} show={show} />
+        </div>
+        {show && <div className="ShowHide_children">{children}</div>}
+    </div>;
+}
+
+ShowHide.propTypes = {
+    className: PropTypes.string,
+    modifier: PropTypes.string,
+    onChange: PropTypes.func,
+    show: PropTypes.bool,
+    toggle: PropTypes.func.isRequired
+};
+
+ShowHide.defaultProps = {
+    onClick: (data) => data,
+    show: false
+}
+
+export default ShowHide;
+
+
+/**
+ * @component
+ *
+ * `ShowHideStateful` is a stateful version of ShowHide.
+ *
+ *
+ * @example
+ * return <ShowHide show={false} onChange={props.onChange} toggle={() => <div>Toggle Me!</div>}>
+ *     <h1>Hello!</h1>
+ * </ShowHide>
+ */
+
+export class ShowHideStateful extends React.Component {
+    state: Object;
+    toggle: Function;
+
+    constructor(props: Object) {
+        super(props);
+        this.state = {
+            show: props.defaultShow || false
+        };
+        this.toggle = this.toggle.bind(this);
+    }
+    toggle(newState: boolean) {
+        this.setState({
+            show: newState
+        });
+        if(this.props.onClick) {
+            this.props.onClick(newState);
+        }
+    }
+    render(): React.Element<ShowHide> {
+        const {show} = this.state;
+        return <ShowHide {...this.props} show={show} onClick={this.toggle}/>;
+    }
+}
+
+ShowHideStateful.propTypes = Object.assign({}, ShowHide.propTypes, {
+    // Default choice to show or hide the content
+    defaultShow: PropTypes.bool
+});
+
+

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,8 @@
 export {default as Button} from './component/button/Button';
 export {default as Table} from './component/table/Table';
 export {default as Label} from './component/field/Label';
+export {default as ShowHide} from './component/showHide/ShowHide';
+export {ShowHideStateful} from './component/showHide/ShowHide';
 
 export {default as Input} from './input/input/Input';
 export {default as Select} from './input/select/Select';


### PR DESCRIPTION
#22

Currently Using `props.show` as the main trigger. Open to better suggestions as `defaultShow` is a silly prop name.

- [x] ShowHide
- [x] ShowHideStateful
- [x] 100% coverage
- [x] Basic example