### PR TITLE
Hock tests, and fixed some docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "jsdoc": "^3.4.2",
     "jsdoc-babel": "^0.2.1",
     "jsdom": "^9.8.3",
-    "jsdonk": "0.4.10",
+    "jsdonk": "0.4.11",
     "node-sass": "^3.11.2",
     "nyc": "^10.0.0",
     "postcss-cli": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "ava": "NODE_ENV=test ava",
     "build": "rm -rf lib && yarn run css && babel src --out-dir lib --copy-files",
     "build-examples": "cd example && yarn install && yarn run build && cd -",
-    "check-coverage": "NODE_ENV=test nyc check-coverage --branches 0.0  --functions 0.0 --lines 0",
+    "check-coverage": "NODE_ENV=test nyc check-coverage --branches 100.0  --functions 100.0 --lines 100",
     "css": "yarn run css-base-combined && yarn run css-default-combined && yarn run css-base && yarn run css-default && yarn run postcss",
     "css-base": "sh scripts/css-base.sh",
     "css-base-combined": "sh scripts/css-base-combined.sh",

--- a/src/hock/ElementQueryHock.jsx
+++ b/src/hock/ElementQueryHock.jsx
@@ -27,15 +27,6 @@ if(typeof window !== 'undefined') { // Don't try to detect resize events on serv
  * @module Hocks
  */
 
-/**
- * `ElementQueryDecorator` is a function that is used to decorate a component
- * with a `ElementQueryHock`, while also passing configuration to it.
- *
- * @param {Array<ElementQueryObject>} eqs An array of element queries to check for.
- *
- * @return {ElementQueryApplier}
- */
-
 const ElementQueryDecorator = (eqs: ElementQuery[]): HockApplier => {
     return (ComposedComponent: ReactClass<any>): ReactClass<any> => {
 
@@ -69,6 +60,8 @@ const ElementQueryDecorator = (eqs: ElementQuery[]): HockApplier => {
          *         heightBounds: [400, 1800]
          *     }
          * ])(example);
+         *
+         * @decorator {ElementQueryHock}
          *
          * @childprop {number}
          * eqWidth The current width of the parent element.
@@ -168,31 +161,42 @@ const ElementQueryDecorator = (eqs: ElementQuery[]): HockApplier => {
 }
 
 /**
- * @typedef ElementQueryObject
+ * Provides configuration for `ElementQueryHock`.
  *
- * @param {String} name
- * The name of the element query.
+ * @callback ElementQueryHock
  *
- * @param {Number[]} [widthBounds=[0, Infinity]]
- * An array containing two values for the minimum (inclusive) and maximum (exclusive)
- * widths allowed by this element query. If the second array item is excluded it is
- * assumed that there is no maximum.
+ * @param {Array<ElementQueryObject>} eqs An array of element queries to check for.
  *
- * @param {Number[]} [heightBounds=[0, Infinity]]
- * An array containing two values for the minimum (inclusive) and maximum (exclusive)
- * heights allowed by this element query. If the second array item is excluded it is
- * assumed that there is no maximum.
+ * @return {ElementQueryWrapper}
  */
 
 /**
- * A decorator function that accepts a component to decorate, and returns that decorated component.
+ * A function that accepts the component you want to wrap in a `ElementQueryHock`.
  *
- * @callback ElementQueryApplier
+ * @callback ElementQueryWrapper
+ *
  * @param {ReactComponent} ComponentToDecorate
  * The component you wish to wrap in an `ElementQueryHock`.
  *
  * @return {ReactComponent}
  * The decorated component.
+ */
+
+/**
+ * @typedef ElementQueryObject
+ *
+ * @property {String} name
+ * The name of the element query.
+ *
+ * @property {Number[]} [widthBounds=[0, Infinity]]
+ * An array containing two values for the minimum (inclusive) and maximum (exclusive)
+ * widths allowed by this element query. If the second array item is excluded it is
+ * assumed that there is no maximum.
+ *
+ * @property {Number[]} [heightBounds=[0, Infinity]]
+ * An array containing two values for the minimum (inclusive) and maximum (exclusive)
+ * heights allowed by this element query. If the second array item is excluded it is
+ * assumed that there is no maximum.
  */
 
 export default ElementQueryDecorator;

--- a/src/hock/PropChangeHock-test.js
+++ b/src/hock/PropChangeHock-test.js
@@ -1,5 +1,126 @@
+import React from 'react';
 import test from 'ava';
+import sinon from 'sinon';
+import PropChangeHock from './PropChangeHock';
 
-test('PropChangeHock', tt => {
-    tt.true(true, 'no test here yet!');
+test('PropChangeHock passes props straight through to children', tt => {
+    const componentToWrap = () => <div>Example Component</div>;
+    const WrappedComponent = PropChangeHock(['aa'], () => {})(componentToWrap);
+    const myWrappedComponent = new WrappedComponent();
+
+    myWrappedComponent.props = {
+        myProp: 'propettyProp'
+    };
+
+    tt.deepEqual(myWrappedComponent.render().props, myWrappedComponent.props);
+});
+
+test('PropChangeHock calls onPropChange function on componentWillMount', tt => {
+    const onPropChange = sinon.spy();
+    const componentToWrap = () => <div>Example Component</div>;
+    const WrappedComponent = PropChangeHock(['aa'], onPropChange)(componentToWrap);
+    const myWrappedComponent = new WrappedComponent();
+
+    myWrappedComponent.props = {
+        myProp: 'propettyProp'
+    };
+
+    myWrappedComponent.componentWillMount();
+
+    tt.true(onPropChange.calledOnce, 'propChange is called');
+    tt.deepEqual(onPropChange.firstCall.args[0], myWrappedComponent.props, 'propChange is passed props from PropChangeHock component');
+});
+
+test('PropChangeHock doesnt call onPropChange function on componentWillReceiveProps when no propKey props have changed', tt => {
+    const onPropChange = sinon.spy();
+    const componentToWrap = () => <div>Example Component</div>;
+    const WrappedComponent = PropChangeHock(['bats'], onPropChange)(componentToWrap);
+    const myWrappedComponent = new WrappedComponent();
+
+    myWrappedComponent.props = {
+        fish: "quiet"
+    };
+
+    const nextProps = {
+        fish: "LOUD"
+    };
+
+    myWrappedComponent.componentWillReceiveProps(nextProps);
+
+    tt.false(onPropChange.called, 'propChange is not called');
+});
+
+test('PropChangeHock calls onPropChange function on componentWillReceiveProps when a propKey prop has changed', tt => {
+    const onPropChange = sinon.spy();
+    const componentToWrap = () => <div>Example Component</div>;
+    const WrappedComponent = PropChangeHock(['bats', 'fish'], onPropChange)(componentToWrap);
+    const myWrappedComponent = new WrappedComponent();
+
+    myWrappedComponent.props = {
+        fish: "quiet"
+    };
+
+    const nextProps = {
+        fish: "LOUD"
+    };
+
+    myWrappedComponent.componentWillReceiveProps(nextProps);
+
+    tt.true(onPropChange.calledOnce, 'propChange is called');
+    tt.deepEqual(onPropChange.firstCall.args[0], nextProps, 'propChange is passed nextProps from PropChangeHock component');
+});
+
+test('PropChangeHock doesnt call onPropChange function on componentWillReceiveProps when no propKey with dots props have changed', tt => {
+    const onPropChange = sinon.spy();
+    const componentToWrap = () => <div>Example Component</div>;
+    const WrappedComponent = PropChangeHock(['bats.wings'], onPropChange)(componentToWrap);
+    const myWrappedComponent = new WrappedComponent();
+
+    myWrappedComponent.props = {
+        bats: {
+            wings: true,
+            thumbs: true,
+            fingers: "ambiguous"
+        }
+    };
+
+    const nextProps = {
+        bats: {
+            wings: true,
+            thumbs: false,
+            fingers: null
+        }
+    };
+
+    myWrappedComponent.componentWillReceiveProps(nextProps);
+
+    tt.false(onPropChange.called, 'propChange is not called');
+});
+
+test('PropChangeHock calls onPropChange function on componentWillReceiveProps when a propKey with dots prop has changed', tt => {
+    const onPropChange = sinon.spy();
+    const componentToWrap = () => <div>Example Component</div>;
+    const WrappedComponent = PropChangeHock(['bats.wings'], onPropChange)(componentToWrap);
+    const myWrappedComponent = new WrappedComponent();
+
+    myWrappedComponent.props = {
+        bats: {
+            wings: true,
+            thumbs: true,
+            fingers: "ambiguous"
+        }
+    };
+
+    const nextProps = {
+        bats: {
+            wings: false,
+            thumbs: true,
+            fingers: "ambiguous"
+        }
+    };
+
+    myWrappedComponent.componentWillReceiveProps(nextProps);
+
+    tt.true(onPropChange.calledOnce, 'propChange is called');
+    tt.deepEqual(onPropChange.firstCall.args[0], nextProps, 'propChange is passed nextProps from PropChangeHock component');
 });

--- a/src/hock/PropChangeHock.jsx
+++ b/src/hock/PropChangeHock.jsx
@@ -7,21 +7,7 @@ import {fromJS} from 'immutable';
  * @module Hocks
  */
 
-/**
- * `PropChangeDecorator` is a function that is used to decorate a component with a `PropChangeHock`
- * while also passing configuration to it.
- *
- * @param {Array<string>} propKeys
- * The props that you want to check for changes on.
- * Nested objects or values can be passed in using dot notation inside strings
- * e.g. `['page', query.name', 'query.age']`.
- *
- * @param {PropChangeFunction} onPropChangeFunction
- *
- * @return {PropChangeApplier}
- */
-
-const PropChangeDecorator = (propKeys: Array<string>, onPropChangeFunction: Function): HockApplier => {
+export default (propKeys: Array<string>, onPropChangeFunction: Function): HockApplier => {
     return (ComponentToDecorate: ReactClass<any>): ReactClass<any> => {
 
         /**
@@ -47,6 +33,9 @@ const PropChangeDecorator = (propKeys: Array<string>, onPropChangeFunction: Func
          *
          * export default withPropChange(MyComponent);
          * // exports MyComponent with PropChangeHock as a higher order component
+         *
+         *
+         * @decorator {PropChangeHock}
          *
          * @memberof module:Hocks
          */
@@ -80,14 +69,28 @@ const PropChangeDecorator = (propKeys: Array<string>, onPropChangeFunction: Func
     }
 }
 
-export default PropChangeDecorator;
+/**
+ * Provides configuration for `PropChangeHock`.
+ *
+ * @callback PropChangeHock
+ *
+ * @param {Array<string>} propKeys
+ * The props that you want to check for changes on.
+ * Nested objects or values can be passed in using dot notation inside strings
+ * e.g. `['page', query.name', 'query.age']`.
+ *
+ * @param {PropChangeFunction} onPropChangeFunction
+ *
+ * @return {PropChangeWrapper}
+ */
 
 /**
- * A decorator function that accepts a component to decorate, and returns that decorated component.
- * @callback PropChangeApplier
+ * A function that accepts the component you want to wrap in a `PropChangeHock`.
+ *
+ * @callback PropChangeWrapper
  *
  * @param {ReactComponent} ComponentToDecorate
- * The component you wish to wrap in a `PropChangeHock`.
+ * The component you wish to wrap in an `PropChangeHock`.
  *
  * @return {ReactComponent}
  * The decorated component.

--- a/src/hock/PropChangeHock.jsx
+++ b/src/hock/PropChangeHock.jsx
@@ -1,7 +1,7 @@
 // @flow
 
 import React, {Component} from 'react';
-import {fromJS} from 'immutable';
+import {fromJS, is} from 'immutable';
 
 /**
  * @module Hocks
@@ -51,9 +51,10 @@ export default (propKeys: Array<string>, onPropChangeFunction: Function): HockAp
                 const propsHaveChanged = fromJS(propKeys)
                     .some(ii => {
                         const keyPath = ii.split('.');
-                        return !thisPropsImmutable
-                            .getIn(keyPath)
-                            .equals(nextPropsImmutable.getIn(keyPath));
+                        return !is(
+                            thisPropsImmutable.getIn(keyPath),
+                            nextPropsImmutable.getIn(keyPath)
+                        );
                     });
 
                 if(propsHaveChanged) {

--- a/src/hock/QueryStringHock-test.js
+++ b/src/hock/QueryStringHock-test.js
@@ -42,6 +42,18 @@ test('QueryStringHock passes query from react router location prop', tt => {
 
 });
 
+test('QueryStringHock passes empty object as query if location prop not provided', tt => {
+
+    const componentToWrap = () => <div>Example Component</div>;
+    const WrappedComponent = QueryStringHock()(componentToWrap);
+    const myWrappedComponent = new WrappedComponent();
+
+    myWrappedComponent.props = {};
+
+    tt.deepEqual(myWrappedComponent.render().props.query, {});
+
+});
+
 test('QueryStringHock should change the name of the query prop if given queryPropName in config', tt => {
 
     const componentToWrap = () => <div>Example Component</div>;
@@ -80,10 +92,14 @@ test('QueryStringHock should convert missing or singular params to array when co
         location: {query}
     };
 
-    tt.deepEqual(myWrappedComponent.render().props.query.a, ["A"], "single query param should now be an array");
-    tt.deepEqual(myWrappedComponent.render().props.query.b, ["B", "B2"], "multiple query param should still array");
-    tt.deepEqual(myWrappedComponent.render().props.query.c, [], "missing query param should be an empty array");
-    tt.deepEqual(myWrappedComponent.render().props.query.d, "D", "other params should remain as they are");
+    const expectedQuery = {
+        a: ["A"], // single query param should now be an array
+        b: ["B", "B2"], // multiple query param should still array
+        c: [], // missing query param should be an empty array
+        d: "D" // other params should remain as they are
+    };
+
+    tt.deepEqual(myWrappedComponent.render().props.query, expectedQuery);
 
 });
 
@@ -108,9 +124,13 @@ test('QueryStringHock should use defaultQuery params when not present in query',
         location: {query}
     };
 
-    tt.deepEqual(myWrappedComponent.render().props.query.a, "A", "Params not in query should use default query");
-    tt.deepEqual(myWrappedComponent.render().props.query.b, "B!", "Params in query string should appear as specified");
-    tt.deepEqual(myWrappedComponent.render().props.query.c, "", "Params in query string as empty strings should not override defaults");
+    const expectedQuery = {
+        a: "A", // Params not in query should use default query
+        b: "B!", // Params in query string should appear as specified
+        c: "C" // Params in query string as empty strings should not override defaults
+    };
+
+    tt.deepEqual(myWrappedComponent.render().props.query, expectedQuery);
 
 });
 
@@ -272,9 +292,7 @@ test('QueryStringHock setQuery should replace existing query completely', tt => 
     const myWrappedComponent = new WrappedComponent();
 
     const push = sinon.spy();
-    const replace = sinon.spy();
 
-    const pathname = "PATH";
     const query = {
         c: "C",
         d: "D"
@@ -282,14 +300,12 @@ test('QueryStringHock setQuery should replace existing query completely', tt => 
 
     myWrappedComponent.context = {
         router: {
-            push,
-            replace
+            push
         }
     };
     myWrappedComponent.props = {
         location: {
-            query,
-            pathname
+            query
         }
     };
 
@@ -300,7 +316,32 @@ test('QueryStringHock setQuery should replace existing query completely', tt => 
 
     myWrappedComponent.render().props.setQuery(newQuery);
 
-    tt.deepEqual(push.firstCall.args[0], {pathname, query: newQuery});
+    tt.deepEqual(push.firstCall.args[0].query, newQuery);
+});
+
+test('QueryStringHock setQuery should noop on missing location prop', tt => {
+
+    const componentToWrap = () => <div>Example Component</div>;
+    const WrappedComponent = QueryStringHock()(componentToWrap);
+    const myWrappedComponent = new WrappedComponent();
+
+    const push = sinon.spy();
+
+    myWrappedComponent.context = {
+        router: {
+            push
+        }
+    };
+    myWrappedComponent.props = {};
+
+    const newQuery = {
+        a: "A",
+        b: "B"
+    };
+
+    myWrappedComponent.render().props.setQuery(newQuery);
+
+    tt.false(push.called);
 });
 
 test('QueryStringHock setQuery should filter out empty strings and nulls', tt => {
@@ -310,21 +351,17 @@ test('QueryStringHock setQuery should filter out empty strings and nulls', tt =>
     const myWrappedComponent = new WrappedComponent();
 
     const push = sinon.spy();
-    const replace = sinon.spy();
 
-    const pathname = "PATH";
     const query = {};
 
     myWrappedComponent.context = {
         router: {
-            push,
-            replace
+            push
         }
     };
     myWrappedComponent.props = {
         location: {
-            query,
-            pathname
+            query
         }
     };
 
@@ -342,7 +379,7 @@ test('QueryStringHock setQuery should filter out empty strings and nulls', tt =>
 
     myWrappedComponent.render().props.setQuery(newQuery);
 
-    tt.deepEqual(push.firstCall.args[0], {pathname, query: expectedQuery});
+    tt.deepEqual(push.firstCall.args[0].query, expectedQuery);
 });
 
 test('QueryStringHock updateQuery should merge with existing query', tt => {
@@ -352,7 +389,6 @@ test('QueryStringHock updateQuery should merge with existing query', tt => {
     const myWrappedComponent = new WrappedComponent();
 
     const push = sinon.spy();
-    const replace = sinon.spy();
 
     const pathname = "PATH";
     const query = {
@@ -362,8 +398,7 @@ test('QueryStringHock updateQuery should merge with existing query', tt => {
 
     myWrappedComponent.context = {
         router: {
-            push,
-            replace
+            push
         }
     };
     myWrappedComponent.props = {
@@ -390,6 +425,33 @@ test('QueryStringHock updateQuery should merge with existing query', tt => {
     tt.deepEqual(push.firstCall.args[0], {pathname, query: expectedQuery});
 });
 
+
+test('QueryStringHock updateQuery should noop on missing location prop', tt => {
+
+    const componentToWrap = () => <div>Example Component</div>;
+    const WrappedComponent = QueryStringHock()(componentToWrap);
+    const myWrappedComponent = new WrappedComponent();
+
+    const push = sinon.spy();
+
+    myWrappedComponent.context = {
+        router: {
+            push
+        }
+    };
+    myWrappedComponent.props = {};
+
+    const newQuery = {
+        a: "A",
+        b: "B"
+    };
+
+    myWrappedComponent.render().props.updateQuery(newQuery);
+
+    tt.false(push.called);
+});
+
+
 test('QueryStringHock updateQuery should filter out empty strings and nulls', tt => {
 
     const componentToWrap = () => <div>Example Component</div>;
@@ -397,9 +459,7 @@ test('QueryStringHock updateQuery should filter out empty strings and nulls', tt
     const myWrappedComponent = new WrappedComponent();
 
     const push = sinon.spy();
-    const replace = sinon.spy();
 
-    const pathname = "PATH";
     const query = {
         b: "B",
         c: "C"
@@ -407,14 +467,12 @@ test('QueryStringHock updateQuery should filter out empty strings and nulls', tt
 
     myWrappedComponent.context = {
         router: {
-            push,
-            replace
+            push
         }
     };
     myWrappedComponent.props = {
         location: {
-            query,
-            pathname
+            query
         }
     };
 
@@ -432,5 +490,72 @@ test('QueryStringHock updateQuery should filter out empty strings and nulls', tt
 
     myWrappedComponent.render().props.updateQuery(newQuery);
 
-    tt.deepEqual(push.firstCall.args[0], {pathname, query: expectedQuery});
+    tt.deepEqual(push.firstCall.args[0].query, expectedQuery);
 });
+
+test('QueryStringHock updateQuery can cope with merging and not merging array params', tt => {
+
+    const componentToWrap = () => <div>Example Component</div>;
+    const WrappedComponent = QueryStringHock({
+        arrayParams: [
+            "noneToNone",
+            "noneToOne",
+            "noneToTwo",
+            "oneToNone",
+            "oneToOne",
+            "oneToTwo",
+            "twoToNone",
+            "twoToOne",
+            "twoToTwo"
+        ]
+    })(componentToWrap);
+    const myWrappedComponent = new WrappedComponent();
+
+    const push = sinon.spy();
+
+    const query = {
+        oneToNone: "one",
+        oneToOne: "one",
+        oneToTwo: "one",
+        twoToNone: ["1", "2"],
+        twoToOne: ["1", "2"],
+        twoToTwo: ["1", "2"]
+    };
+
+    myWrappedComponent.context = {
+        router: {
+            push
+        }
+    };
+    myWrappedComponent.props = {
+        location: {
+            query
+        }
+    };
+
+    const newQuery = {
+        noneToNone: "",
+        noneToOne: "one!",
+        noneToTwo: ["1!", "2!"],
+        oneToNone: "",
+        oneToOne: "one!",
+        oneToTwo: ["1!", "2!"],
+        twoToNone: null,
+        twoToOne: "one!",
+        twoToTwo: ["1!", "2!"]
+    };
+
+    const expectedQuery = {
+        noneToOne: "one!",
+        noneToTwo: ["1!", "2!"],
+        oneToOne: "one!",
+        oneToTwo: ["1!", "2!"],
+        twoToOne: "one!",
+        twoToTwo: ["1!", "2!"]
+    };
+
+    myWrappedComponent.render().props.updateQuery(newQuery);
+
+    tt.deepEqual(push.firstCall.args[0].query, expectedQuery);
+});
+

--- a/src/hock/QueryStringHock-test.js
+++ b/src/hock/QueryStringHock-test.js
@@ -1,0 +1,436 @@
+import React from 'react';
+import test from 'ava';
+import sinon from 'sinon';
+import QueryStringHock from './QueryStringHock';
+import {fromJS} from 'immutable';
+
+test('QueryStringHock passes props straight through to children', tt => {
+
+    const componentToWrap = () => <div>Example Component</div>;
+    const WrappedComponent = QueryStringHock()(componentToWrap);
+    const myWrappedComponent = new WrappedComponent();
+
+    myWrappedComponent.props = {
+        myProp: 'propettyProp'
+    };
+
+    // remove props provided by QueryString
+    const expectedProps = fromJS(myWrappedComponent.render().props)
+        .delete('setQuery')
+        .delete('updateQuery')
+        .delete('query')
+        .toJS();
+
+    tt.deepEqual(expectedProps, myWrappedComponent.props);
+});
+
+test('QueryStringHock passes query from react router location prop', tt => {
+
+    const componentToWrap = () => <div>Example Component</div>;
+    const WrappedComponent = QueryStringHock()(componentToWrap);
+    const myWrappedComponent = new WrappedComponent();
+
+    const query = {
+        a: "A"
+    };
+
+    myWrappedComponent.props = {
+        location: {query}
+    };
+
+    tt.deepEqual(myWrappedComponent.render().props.query, query);
+
+});
+
+test('QueryStringHock should change the name of the query prop if given queryPropName in config', tt => {
+
+    const componentToWrap = () => <div>Example Component</div>;
+    const WrappedComponent = QueryStringHock({
+        queryPropName: "coolQueryTime"
+    })(componentToWrap);
+    const myWrappedComponent = new WrappedComponent();
+
+    const query = {
+        a: "A"
+    };
+
+    myWrappedComponent.props = {
+        location: {query}
+    };
+
+    tt.deepEqual(myWrappedComponent.render().props.coolQueryTime, query);
+
+});
+
+test('QueryStringHock should convert missing or singular params to array when config.arrayParams is used', tt => {
+
+    const componentToWrap = () => <div>Example Component</div>;
+    const WrappedComponent = QueryStringHock({
+        arrayParams: ['a', 'b', 'c']
+    })(componentToWrap);
+    const myWrappedComponent = new WrappedComponent();
+
+    const query = {
+        a: "A",
+        b: ["B", "B2"],
+        d: "D"
+    };
+
+    myWrappedComponent.props = {
+        location: {query}
+    };
+
+    tt.deepEqual(myWrappedComponent.render().props.query.a, ["A"], "single query param should now be an array");
+    tt.deepEqual(myWrappedComponent.render().props.query.b, ["B", "B2"], "multiple query param should still array");
+    tt.deepEqual(myWrappedComponent.render().props.query.c, [], "missing query param should be an empty array");
+    tt.deepEqual(myWrappedComponent.render().props.query.d, "D", "other params should remain as they are");
+
+});
+
+test('QueryStringHock should use defaultQuery params when not present in query', tt => {
+
+    const componentToWrap = () => <div>Example Component</div>;
+    const WrappedComponent = QueryStringHock({
+        defaultQuery: {
+            a: "A",
+            b: "B",
+            c: "C"
+        }
+    })(componentToWrap);
+    const myWrappedComponent = new WrappedComponent();
+
+    const query = {
+        b: "B!",
+        c: ""
+    };
+
+    myWrappedComponent.props = {
+        location: {query}
+    };
+
+    tt.deepEqual(myWrappedComponent.render().props.query.a, "A", "Params not in query should use default query");
+    tt.deepEqual(myWrappedComponent.render().props.query.b, "B!", "Params in query string should appear as specified");
+    tt.deepEqual(myWrappedComponent.render().props.query.c, "", "Params in query string as empty strings should not override defaults");
+
+});
+
+test('QueryStringHock should set query via history prop for react-router v1 using pushState', tt => {
+
+    const componentToWrap = () => <div>Example Component</div>;
+    const WrappedComponent = QueryStringHock()(componentToWrap);
+    const myWrappedComponent = new WrappedComponent();
+
+    const pushState = sinon.spy();
+    const replaceState = sinon.spy();
+
+    const pathname = "PATH";
+    const query = {};
+
+    myWrappedComponent.context = {};
+    myWrappedComponent.props = {
+        location: {
+            query,
+            pathname
+        },
+        history: {
+            pushState,
+            replaceState
+        }
+    };
+
+    const newQuery = {
+        a: "A"
+    };
+
+    myWrappedComponent.render().props.setQuery(newQuery);
+
+    tt.true(pushState.calledOnce, 'history.pushState is called');
+    tt.is(pushState.firstCall.args[0], null, 'First arg should be null');
+    tt.is(pushState.firstCall.args[1], pathname, 'Second arg should be location.pathname');
+    tt.deepEqual(pushState.firstCall.args[2], newQuery, 'Third arg should be the query passed in');
+    tt.false(replaceState.called, 'history.replaceState should not be called');
+});
+
+test('QueryStringHock should set query via history prop for react-router v1 using replaceState', tt => {
+
+    const componentToWrap = () => <div>Example Component</div>;
+    const WrappedComponent = QueryStringHock({
+        replaceState: true
+    })(componentToWrap);
+    const myWrappedComponent = new WrappedComponent();
+
+    const pushState = sinon.spy();
+    const replaceState = sinon.spy();
+
+    const pathname = "PATH";
+    const query = {};
+
+    myWrappedComponent.context = {};
+    myWrappedComponent.props = {
+        location: {
+            query,
+            pathname
+        },
+        history: {
+            pushState,
+            replaceState
+        }
+    };
+
+    const newQuery = {
+        a: "A"
+    };
+
+    myWrappedComponent.render().props.setQuery(newQuery);
+
+    tt.true(replaceState.calledOnce, 'history.replaceState is called');
+    tt.is(replaceState.firstCall.args[0], null, 'First arg should be null');
+    tt.is(replaceState.firstCall.args[1], pathname, 'Second arg should be location.pathname');
+    tt.deepEqual(replaceState.firstCall.args[2], newQuery, 'Third arg should be the query passed in');
+    tt.false(pushState.called, 'history.pushState should not be called');
+});
+
+test('QueryStringHock should set query via conext.router prop for react-router v2+ using pushState', tt => {
+
+    const componentToWrap = () => <div>Example Component</div>;
+    const WrappedComponent = QueryStringHock()(componentToWrap);
+    const myWrappedComponent = new WrappedComponent();
+
+    const push = sinon.spy();
+    const replace = sinon.spy();
+
+    const pathname = "PATH";
+    const query = {};
+
+    myWrappedComponent.context = {
+        router: {
+            push,
+            replace
+        }
+    };
+    myWrappedComponent.props = {
+        location: {
+            query,
+            pathname
+        }
+    };
+
+    const newQuery = {
+        a: "A"
+    };
+
+    myWrappedComponent.render().props.setQuery(newQuery);
+
+    tt.true(push.calledOnce, 'router.push is called');
+    tt.deepEqual(push.firstCall.args[0], {pathname, query: newQuery}, 'First arg should contain pathname and new query');
+    tt.false(replace.called, 'router.replace should not be called');
+});
+
+
+test('QueryStringHock should set query via conext.router prop for react-router v2+ using replaceState', tt => {
+
+    const componentToWrap = () => <div>Example Component</div>;
+    const WrappedComponent = QueryStringHock({
+        replaceState: true
+    })(componentToWrap);
+    const myWrappedComponent = new WrappedComponent();
+
+    const push = sinon.spy();
+    const replace = sinon.spy();
+
+    const pathname = "PATH";
+    const query = {};
+
+    myWrappedComponent.context = {
+        router: {
+            push,
+            replace
+        }
+    };
+    myWrappedComponent.props = {
+        location: {
+            query,
+            pathname
+        }
+    };
+
+    const newQuery = {
+        a: "A"
+    };
+
+    myWrappedComponent.render().props.setQuery(newQuery);
+
+    tt.true(replace.calledOnce, 'router.replace is called');
+    tt.deepEqual(replace.firstCall.args[0], {pathname, query: newQuery}, 'First arg should contain pathname and new query');
+    tt.false(push.called, 'router.push should not be called');
+});
+
+test('QueryStringHock setQuery should replace existing query completely', tt => {
+
+    const componentToWrap = () => <div>Example Component</div>;
+    const WrappedComponent = QueryStringHock()(componentToWrap);
+    const myWrappedComponent = new WrappedComponent();
+
+    const push = sinon.spy();
+    const replace = sinon.spy();
+
+    const pathname = "PATH";
+    const query = {
+        c: "C",
+        d: "D"
+    };
+
+    myWrappedComponent.context = {
+        router: {
+            push,
+            replace
+        }
+    };
+    myWrappedComponent.props = {
+        location: {
+            query,
+            pathname
+        }
+    };
+
+    const newQuery = {
+        a: "A",
+        b: "B"
+    };
+
+    myWrappedComponent.render().props.setQuery(newQuery);
+
+    tt.deepEqual(push.firstCall.args[0], {pathname, query: newQuery});
+});
+
+test('QueryStringHock setQuery should filter out empty strings and nulls', tt => {
+
+    const componentToWrap = () => <div>Example Component</div>;
+    const WrappedComponent = QueryStringHock()(componentToWrap);
+    const myWrappedComponent = new WrappedComponent();
+
+    const push = sinon.spy();
+    const replace = sinon.spy();
+
+    const pathname = "PATH";
+    const query = {};
+
+    myWrappedComponent.context = {
+        router: {
+            push,
+            replace
+        }
+    };
+    myWrappedComponent.props = {
+        location: {
+            query,
+            pathname
+        }
+    };
+
+    const newQuery = {
+        a: "A",
+        b: "",
+        c: ["c", "C"],
+        d: null
+    };
+
+    const expectedQuery = {
+        a: "A",
+        c: ["c", "C"]
+    };
+
+    myWrappedComponent.render().props.setQuery(newQuery);
+
+    tt.deepEqual(push.firstCall.args[0], {pathname, query: expectedQuery});
+});
+
+test('QueryStringHock updateQuery should merge with existing query', tt => {
+
+    const componentToWrap = () => <div>Example Component</div>;
+    const WrappedComponent = QueryStringHock()(componentToWrap);
+    const myWrappedComponent = new WrappedComponent();
+
+    const push = sinon.spy();
+    const replace = sinon.spy();
+
+    const pathname = "PATH";
+    const query = {
+        c: "C",
+        d: "D"
+    };
+
+    myWrappedComponent.context = {
+        router: {
+            push,
+            replace
+        }
+    };
+    myWrappedComponent.props = {
+        location: {
+            query,
+            pathname
+        }
+    };
+
+    const newQuery = {
+        a: "A",
+        b: "B"
+    };
+
+    const expectedQuery = {
+        a: "A",
+        b: "B",
+        c: "C",
+        d: "D"
+    };
+
+    myWrappedComponent.render().props.updateQuery(newQuery);
+
+    tt.deepEqual(push.firstCall.args[0], {pathname, query: expectedQuery});
+});
+
+test('QueryStringHock updateQuery should filter out empty strings and nulls', tt => {
+
+    const componentToWrap = () => <div>Example Component</div>;
+    const WrappedComponent = QueryStringHock()(componentToWrap);
+    const myWrappedComponent = new WrappedComponent();
+
+    const push = sinon.spy();
+    const replace = sinon.spy();
+
+    const pathname = "PATH";
+    const query = {
+        b: "B",
+        c: "C"
+    };
+
+    myWrappedComponent.context = {
+        router: {
+            push,
+            replace
+        }
+    };
+    myWrappedComponent.props = {
+        location: {
+            query,
+            pathname
+        }
+    };
+
+    const newQuery = {
+        a: "A",
+        b: "",
+        c: "C!",
+        d: null
+    };
+
+    const expectedQuery = {
+        a: "A",
+        c: "C!"
+    };
+
+    myWrappedComponent.render().props.updateQuery(newQuery);
+
+    tt.deepEqual(push.firstCall.args[0], {pathname, query: expectedQuery});
+});

--- a/src/hock/QueryStringHock.jsx
+++ b/src/hock/QueryStringHock.jsx
@@ -108,7 +108,10 @@ export default (config: ?Object = null, onQueryChangeFunction: ?Function = null,
              */
 
             getQuery(props: Object): Object {
-                const query: Map<string,any> = defaultQuery.merge(fromJS(props.location.query));
+                const existingQuery: Object = (props.location && props.location.query) || {};
+                const query: Map<string,any> = defaultQuery.merge(
+                    fromJS(existingQuery).filter(ii => ii != "")
+                );
 
                 // ensures that all arrayParams are returned as arrays (not strings or blank)
                 return arrayParams
@@ -132,7 +135,8 @@ export default (config: ?Object = null, onQueryChangeFunction: ?Function = null,
              */
 
             updateQuery(queryParamsToUpdate: Object) {
-                const query = fromJS(this.props.location.query)
+                const existingQuery: Object = (this.props.location && this.props.location.query) || {};
+                const query = fromJS(existingQuery)
                     .merge(fromJS(queryParamsToUpdate))
                     .toJS();
                 this.setQuery(query);

--- a/src/hock/QueryStringHock.jsx
+++ b/src/hock/QueryStringHock.jsx
@@ -8,22 +8,7 @@ import PropChangeHock from './PropChangeHock';
  * @module Hocks
  */
 
-/**
- * `PropChangeDecorator` is a function that is used to decorate a component with a `QueryStringHock`
- * while also passing configuration to it.
- *
- * @param {QueryStringDecoratorConfig} [config]
- *
- * @param {QueryChangeFunction} [onQueryChangeFunction]
- *
- * @param {Array<string>} [onChangeParams]
- * An optional array of query parameters that, once changed,
- * will cause `onQueryChangeFunction` to be fired.
- *
- * @return {QueryStringApplier}
- */
-
-const QueryStringDecorator = (config: ?Object = null, onQueryChangeFunction: ?Function = null, onChangeParams: ?Array<string> = null): HockApplier => {
+export default (config: ?Object = null, onQueryChangeFunction: ?Function = null, onChangeParams: ?Array<string> = null): HockApplier => {
     return (ComposedComponent: ReactClass<any>): ReactClass<any> => {
 
         const replaceState: boolean = !!(config && config.replaceState);
@@ -82,6 +67,8 @@ const QueryStringDecorator = (config: ?Object = null, onQueryChangeFunction: ?Fu
          *
          * export default withQueryString(MyComponent);
          * // exports MyComponent with QueryStringHock as a higher order component
+         *
+         * @decorator {QueryStringHock}
          *
          * @prop {Object} location
          * Required for `react-router` v1 and v2. Must be react router location object.
@@ -206,13 +193,38 @@ const QueryStringDecorator = (config: ?Object = null, onQueryChangeFunction: ?Fu
     }
 };
 
-export default QueryStringDecorator;
-
+/**
+ * Provides configuration for `QueryStringHock`.
+ *
+ * @callback QueryStringHock
+ *
+ * @param {QueryStringHockConfig} [config]
+ *
+ * @param {QueryChangeFunction} [onQueryChangeFunction]
+ *
+ * @param {Array<string>} [onChangeParams]
+ * An optional array of query parameters that, once changed,
+ * will cause `onQueryChangeFunction` to be fired.
+ *
+ * @return {QueryStringWrapper}
+ */
 
 /**
- * Configuration object for the QueryStringDecorator.
+ * A function that accepts the component you want to wrap in a `QueryStringHock`.
  *
- * @typedef QueryStringDecoratorConfig
+ * @callback QueryStringWrapper
+ *
+ * @param {ReactComponent} ComponentToDecorate
+ * The component you wish to wrap in an `QueryStringHock`.
+ *
+ * @return {ReactComponent}
+ * The decorated component.
+ */
+
+/**
+ * Configuration object for the QueryStringHock.
+ *
+ * @typedef QueryStringHockConfig
  *
  * @property {Object} [defaultQuery]
  * These defaults will be passed down in the query prop
@@ -231,13 +243,6 @@ export default QueryStringDecorator;
  * if they are not present in the query string.
  * By default `react-router` only passes an array of query param values back
  * if there are more than one value in them.
- */
-
-/**
- * A decorator function that accepts a component to decorate, and returns that decorated component.
- * @callback QueryStringApplier
- * @param {ReactComponent} ComponentToDecorate The component you wish to wrap in a `QueryStringHock`.
- * @return {ReactComponent} The decorated component.
  */
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -13,3 +13,4 @@ export {default as SpruceComponent} from './util/SpruceComponent';
 
 export {default as ElementQueryHock} from './hock/ElementQueryHock';
 export {default as PropChangeHock} from './hock/PropChangeHock';
+export {default as QueryStringHock} from './hock/QueryStringHock';

--- a/src/index.js
+++ b/src/index.js
@@ -12,3 +12,4 @@ export {default as SpruceClassName} from './util/SpruceClassName';
 export {default as SpruceComponent} from './util/SpruceComponent';
 
 export {default as ElementQueryHock} from './hock/ElementQueryHock';
+export {default as PropChangeHock} from './hock/PropChangeHock';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1106,9 +1106,9 @@ browserslist@~1.4.0:
   dependencies:
     caniuse-db "^1.0.30000539"
 
-bruce@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/bruce/-/bruce-0.6.0.tgz#a3ff27b5621ada8972f24f9f368595eadfc9b03b"
+bruce@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/bruce/-/bruce-0.9.0.tgz#bec3d4a2a13eaddc8c72be6ca398e0b0043d1f9f"
   dependencies:
     exports-loader "^0.6.2"
 
@@ -2880,9 +2880,9 @@ jsdom@^9.8.3:
     whatwg-url "^3.0.0"
     xml-name-validator ">= 2.0.1 < 3.0.0"
 
-jsdonk@0.4.7:
-  version "0.4.7"
-  resolved "https://registry.yarnpkg.com/jsdonk/-/jsdonk-0.4.7.tgz#a20d093244c84fec4e55a2b277ec398cd1533b6f"
+jsdonk@0.4.11:
+  version "0.4.11"
+  resolved "https://registry.yarnpkg.com/jsdonk/-/jsdonk-0.4.11.tgz#700f00d846db6380b412f25bd900ba4d7d4278b1"
   dependencies:
     immutable "^3.8.1"
     prismjs "^1.5.1"
@@ -4103,11 +4103,7 @@ resolve-from@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-2.0.0.tgz#9480ab20e94ffa1d9e80a804c7ea147611966b57"
 
-resolve@^1.1.6:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.2.0.tgz#9589c3f2f6149d1417a40becc1663db6ec6bc26c"
-
-resolve@~1.1.7:
+resolve@^1.1.6, resolve@~1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 


### PR DESCRIPTION
## PropChangeHock

- Now wont break on receiving new props when a `propKey` path doesn't correspond to an actual prop
- Now has tests and full coverage
- Added as named export

## QueryStringHock

- Remove the embedded `PoprChangeHock` stuff - difficult to test and nowhere near as useful or used as I first thought it would be.
- Checks and warns when missing location prop
- In passed down query prop, an empty string param no longer replaces default query param, bringing it in line with the rest of its behaviour that assumes empty strings and nulls are to be treated as though the param doesnt exist
- Now has tests and full coverage
- Added as named export

## Docs

Structurally this is much better than it used to be.

There's a bug in jsdonk that's causing a bunch of meaningless typedef names show up instead of showing the action types, so might look a bit Java-y in the mean time. Once that's fixed then this stuff...

**QueryStringHock:** `(config?: QueryStringHockConfig, onQueryChangeFunction?: QueryChangeFunction, onChangeParams?: Array.<string>) => QueryStringWrapper`
Provides configuration for QueryStringHock.
- config: `?QueryStringHockConfig`
- onQueryChangeFunction: `?QueryChangeFunction`
- onChangeParams: `?Array.<string>` An optional array of query parameters that, once changed, will cause onQueryChangeFunction to be fired.
- returns: `QueryStringWrapper`

... will be more like

**QueryStringHock:** `(config?: Object, onQueryChangeFunction?: Function, onChangeParams?: Array.<string>) => Function`
Provides configuration for QueryStringHock.
- config: `?Object Object`
  Configuration object for the QueryStringHock.
  - defaultQuery `Object`
  - queryPropName = "query"
- onQueryChangeFunction: `?Function`
  A function to be called when the query string changes. By default this function is called on initial `componentDidMount` and every time any query param changes after this to limit this use the third argument `onChangeParams`.
  - query `Object`
  - nextProps `Object`
- onChangeParams: `?Array.<string>` An optional array of query parameters that, once changed, will cause onQueryChangeFunction to be fired.
- returns: `...`
