### PR TITLE
Rename ToggleSet > Toggle.className

### DIFF
--- a/src/input/toggleSet/ToggleSet.jsx
+++ b/src/input/toggleSet/ToggleSet.jsx
@@ -105,6 +105,7 @@ function ToggleSet(props: ToggleSetProps): React.Element<any> {
                 disabled={disabled}
                 onChange={toggleOnChange}
                 toggleProps={toggleProps}
+                spruceName="ToggleSet_toggle"
                 value={selection.has(value)}
             />;
         })


### PR DESCRIPTION
- make Toggle sets ToggleSet_toggle instead of Toggle

This is more consistent with spruce. Toggle has its own styling concerns