### PR TITLE
Feature/query string hock rr4

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -22,7 +22,6 @@
     "eslint": "^3.10.2",
     "eslint-config-blueflag": "^0.2.0",
     "extract-text-webpack-plugin": "^1.0.1",
-    "immutable-recursive": "^0.0.6",
     "json-loader": "^0.5.4",
     "node-sass": "^3.13.0",
     "postcss": "^5.2.5",
@@ -33,13 +32,13 @@
     "webpack-dev-server": "^1.16.2"
   },
   "dependencies": {
+    "bruce": "^0.6.0",
     "classnames": "^2.2.5",
     "element-resize-detector": "^1.1.9",
-    "bruce": "^0.6.0",
     "immutable": "^3.8.1",
     "react": "^15.3.2",
     "react-dom": "^15.3.2",
-    "react-router": "^3.0.0",
+    "react-router-dom": "^4.0.0",
     "react-select": "^1.0.0-rc.2",
     "redux": "^3.6.0",
     "redux-form": "^6.2.0"

--- a/example/src/components/AppHandler.jsx
+++ b/example/src/components/AppHandler.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import {Link} from 'react-router';
 export default (props) => {
     return <div>
         {props.children}

--- a/example/src/components/ContentsPage.jsx
+++ b/example/src/components/ContentsPage.jsx
@@ -10,9 +10,14 @@ export default () => {
         .children
         .map(route => {
             const {path} = route.props;
+            if(!path) {
+                return null;
+            }
             return <li key={path}>
                 <Link to={path}>{path}</Link>
             </li>;
-        });
+        })
+        .filter(ii => ii);
+
     return <ul>{links}</ul>;
 }

--- a/example/src/components/ContentsPage.jsx
+++ b/example/src/components/ContentsPage.jsx
@@ -1,36 +1,18 @@
 import React from 'react';
-import {Link} from 'react-router';
-import {fromJS, List} from 'immutable'
-import {
-    deepFilter,
-    deepMap,
-    deepMapOutwards,
-    deepPick,
-    deepReduceOutwards
-} from 'immutable-recursive';
+import {Link} from 'react-router-dom';
+import Routes from '../routes';
 
-export default (props) => {
-    const routeChildPath = ['childRoutes'];
-    const lists = fromJS(props.routes)
-        .first()
-        .update(deepFilter(ii => ii.get('path') != "*", routeChildPath))
-        .update(deepMap((node, path, tree) => {
-
-            // children will be either undefined,
-            // or they will already be JSX elements by the time parents start grabbing them
-            const children = node
-                .getIn(routeChildPath, List())
-                .update(list => list ? <ul>{list.toJS()}</ul>: null);
-
-            const fullPath = tree
-                .update(deepPick(path, routeChildPath))
-                .update(deepReduceOutwards((all, node) => all.push(node), List(), routeChildPath))
-                .rest()
-                .map(ii => ii.get('path'))
-                .join('/');
-
-            return <li key={path.last()}><Link to={fullPath}>{node.get('path')}</Link> {children}</li>;
-        }, routeChildPath));
-
-    return <ul>{lists}</ul>
+export default () => {
+    const links = Routes
+        .props
+        .children
+        .props
+        .children
+        .map(route => {
+            const {path} = route.props;
+            return <li key={path}>
+                <Link to={path}>{path}</Link>
+            </li>;
+        });
+    return <ul>{links}</ul>;
 }

--- a/example/src/components/ContentsPage.jsx
+++ b/example/src/components/ContentsPage.jsx
@@ -1,11 +1,9 @@
 import React from 'react';
 import {Link} from 'react-router-dom';
-import Routes from '../routes';
+import {routesList} from '../routes';
 
 export default () => {
-    const links = Routes
-        .props
-        .children
+    const links = routesList
         .props
         .children
         .map(route => {

--- a/example/src/hock/QueryStringHockExample.jsx
+++ b/example/src/hock/QueryStringHockExample.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import {QueryStringHock} from 'stampy';
+
+const Example = (props) => {
+    const {
+        query,
+        setQuery,
+        updateQuery
+    } = props;
+
+    console.log('Props:', props);
+
+    return <div>
+        <button onClick={() => updateQuery({foo: "FOO"})}>Add "foo=FOO" to query string</button>
+        <button onClick={() => updateQuery({foo: "YEAH"})}>Add "foo=YEAH" to query string</button>
+        <button onClick={() => updateQuery({bar: "BAR"})}>Add "bar=BAR" to query string</button>
+        <button onClick={() => updateQuery({bar: null})}>Remove "bar" from query string</button>
+        <button onClick={() => updateQuery({arr: ["A", "B"]})}>Add "arr=A&arr=B" to query string</button>
+        <button onClick={() => setQuery({baz: "BAZ"})}>Replace query string completely with "baz=BAZ"</button>
+        <button onClick={() => setQuery({})}>Clear query string</button>
+    </div>;
+}
+
+Example.propTypes = {
+    setQuery: React.PropTypes.func,
+    updateQuery: React.PropTypes.func
+};
+
+const QueryStringHockExample = QueryStringHock({
+    arrayParams: ['arr']
+})(Example);
+
+export default QueryStringHockExample;

--- a/example/src/index.js
+++ b/example/src/index.js
@@ -1,11 +1,8 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import {Router, hashHistory} from 'react-router';
-import routes from 'routes';
+import Routes from 'routes';
 import 'sass/style.scss';
 
 const appElement = document.getElementById('app');
 
-ReactDOM.render((
-    <Router history={hashHistory} routes={routes}/>
-), appElement);
+ReactDOM.render(Routes, appElement);

--- a/example/src/routes.jsx
+++ b/example/src/routes.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {HashRouter, Route} from 'react-router-dom';
+import {HashRouter, Switch, Route} from 'react-router-dom';
 
 import AppHandler from 'components/AppHandler';
 import ErrorHandler from 'components/ErrorHandler';
@@ -22,23 +22,27 @@ import QueryStringHockExample from 'hock/QueryStringHockExample';
 import SpruceClassNameExample from 'util/SpruceClassNameExample';
 import SpruceComponentExample from 'util/SpruceComponentExample';
 
+export const routesList = <Switch>
+    <Route exact path="/" component={ContentsPage} />
+    <Route path="/component/Button" component={ButtonExample}/>
+    <Route path="/component/Label" component={LabelExample}/>
+    <Route path="/component/ShowHide" component={ShowHideExample}/>
+    <Route path="/component/Table" component={TableExample}/>
+    <Route path="/input/Input" component={InputExample}/>
+    <Route path="/input/Select" component={SelectExample}/>
+    <Route path="/input/Toggle" component={ToggleExample}/>
+    <Route path="/input/ToggleSet" component={ToggleSetExample}/>
+    <Route path="/util/SpruceClassName" component={SpruceClassNameExample}/>
+    <Route path="/util/SpruceComponent" component={SpruceComponentExample}/>
+    <Route path="/hock/ElementQueryHock" component={ElementQueryHockExample}/>
+    <Route path="/hock/ElementQueryHockStressTest" component={ElementQueryHockStressTest}/>
+    <Route path="/hock/QueryStringHock" component={QueryStringHockExample}/>
+    <Route component={ErrorHandler} />
+</Switch>;
+
 const Routes = <HashRouter>
     <AppHandler>
-        <Route exact path="/" component={ContentsPage} />
-        <Route path="/component/Button" component={ButtonExample}/>
-        <Route path="/component/Label" component={LabelExample}/>
-        <Route path="/component/ShowHide" component={ShowHideExample}/>
-        <Route path="/component/Table" component={TableExample}/>
-        <Route path="/input/Input" component={InputExample}/>
-        <Route path="/input/Select" component={SelectExample}/>
-        <Route path="/input/Toggle" component={ToggleExample}/>
-        <Route path="/input/ToggleSet" component={ToggleSetExample}/>
-        <Route path="/util/SpruceClassName" component={SpruceClassNameExample}/>
-        <Route path="/util/SpruceComponent" component={SpruceComponentExample}/>
-        <Route path="/hock/ElementQueryHock" component={ElementQueryHockExample}/>
-        <Route path="/hock/ElementQueryHockStressTest" component={ElementQueryHockStressTest}/>
-        <Route path="/hock/QueryStringHock" component={QueryStringHockExample}/>
-        {/*<Route component={ErrorHandler} />*/}
+        {routesList}
     </AppHandler>
 </HashRouter>;
 

--- a/example/src/routes.jsx
+++ b/example/src/routes.jsx
@@ -38,9 +38,8 @@ const Routes = <HashRouter>
         <Route path="/hock/ElementQueryHock" component={ElementQueryHockExample}/>
         <Route path="/hock/ElementQueryHockStressTest" component={ElementQueryHockStressTest}/>
         <Route path="/hock/QueryStringHock" component={QueryStringHockExample}/>
+        {/*<Route component={ErrorHandler} />*/}
     </AppHandler>
 </HashRouter>;
-
-// how do we do ErrorHandler now in react router v4?
 
 export default Routes;

--- a/example/src/routes.jsx
+++ b/example/src/routes.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Route, IndexRoute} from 'react-router';
+import {HashRouter, Route} from 'react-router-dom';
 
 import AppHandler from 'components/AppHandler';
 import ErrorHandler from 'components/ErrorHandler';
@@ -17,35 +17,30 @@ import ToggleSetExample from 'input/toggleSet/ToggleSetExample';
 
 import ElementQueryHockExample from 'hock/ElementQueryHockExample';
 import ElementQueryHockStressTest from 'hock/ElementQueryHockStressTest';
+import QueryStringHockExample from 'hock/QueryStringHockExample';
 
 import SpruceClassNameExample from 'util/SpruceClassNameExample';
 import SpruceComponentExample from 'util/SpruceComponentExample';
 
-const routes = <Route component={AppHandler} path="/">
-    <IndexRoute component={ContentsPage} />
-    <Route path="component">
-        <Route path="Button" component={ButtonExample}/>
-        <Route path="Label" component={LabelExample}/>
-        <Route path="ShowHide" component={ShowHideExample}/>
-        <Route path="Table" component={TableExample}/>
-    </Route>
-    <Route path="input">
-        <Route path="Input" component={InputExample}/>
-        <Route path="Select" component={SelectExample}/>
-        <Route path="Toggle" component={ToggleExample}/>
-        <Route path="ToggleSet" component={ToggleSetExample}/>
-    </Route>
-    <Route path="util">
-        <Route path="SpruceClassName" component={SpruceClassNameExample}/>
-        <Route path="SpruceComponent" component={SpruceComponentExample}/>
-    </Route>
+const Routes = <HashRouter>
+    <AppHandler>
+        <Route exact path="/" component={ContentsPage} />
+        <Route path="/component/Button" component={ButtonExample}/>
+        <Route path="/component/Label" component={LabelExample}/>
+        <Route path="/component/ShowHide" component={ShowHideExample}/>
+        <Route path="/component/Table" component={TableExample}/>
+        <Route path="/input/Input" component={InputExample}/>
+        <Route path="/input/Select" component={SelectExample}/>
+        <Route path="/input/Toggle" component={ToggleExample}/>
+        <Route path="/input/ToggleSet" component={ToggleSetExample}/>
+        <Route path="/util/SpruceClassName" component={SpruceClassNameExample}/>
+        <Route path="/util/SpruceComponent" component={SpruceComponentExample}/>
+        <Route path="/hock/ElementQueryHock" component={ElementQueryHockExample}/>
+        <Route path="/hock/ElementQueryHockStressTest" component={ElementQueryHockStressTest}/>
+        <Route path="/hock/QueryStringHock" component={QueryStringHockExample}/>
+    </AppHandler>
+</HashRouter>;
 
-    <Route path="hock">
-        <Route path="ElementQueryHock" component={ElementQueryHockExample}/>
-        <Route path="ElementQueryHockStressTest" component={ElementQueryHockStressTest}/>
-    </Route>
+// how do we do ErrorHandler now in react router v4?
 
-    <Route path="*" component={ErrorHandler}/>
-</Route>;
-
-export default routes;
+export default Routes;

--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -37,7 +37,8 @@ const development = {
         root: [path.resolve(__dirname, './src'), path.resolve(__dirname, './node_modules')],
         alias: {
             stampy: path.resolve(__dirname, "../")
-        }
+        },
+        fallback: path.resolve(__dirname, '../node_modules')
     },
     plugins: [
         new webpack.DefinePlugin({

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -1962,13 +1962,14 @@ hawk@~3.1.3:
     hoek "2.x.x"
     sntp "1.x.x"
 
-history@^3.0.0:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/history/-/history-3.2.1.tgz#71c7497f4e6090363d19a6713bb52a1bfcdd99aa"
+history@^4.5.1, history@^4.6.0:
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/history/-/history-4.6.1.tgz#911cf8eb65728555a94f2b12780a0c531a14d2fd"
   dependencies:
     invariant "^2.2.1"
     loose-envify "^1.2.0"
-    query-string "^4.2.2"
+    resolve-pathname "^2.0.0"
+    value-equal "^0.2.0"
     warning "^3.0.0"
 
 hoek@2.x.x:
@@ -2288,6 +2289,10 @@ is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
 
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
@@ -2513,7 +2518,7 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
@@ -2944,6 +2949,12 @@ path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
 
+path-to-regexp@^1.5.3:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
+  dependencies:
+    isarray "0.0.1"
+
 path-type@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-1.1.0.tgz#59c44f7ee491da704da415da5a4070ba4f8fe441"
@@ -3319,7 +3330,7 @@ qs@~6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.3.0.tgz#f403b264f23bc01228c74131b407f18d5ea5d442"
 
-query-string@^4.1.0, query-string@^4.2.2:
+query-string@^4.1.0:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/query-string/-/query-string-4.3.1.tgz#54baada6713eafc92be75c47a731f2ebd09cd11d"
   dependencies:
@@ -3370,14 +3381,21 @@ react-input-autosize@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/react-input-autosize/-/react-input-autosize-1.1.0.tgz#3fe1ac832387d8abab85f6051ceab1c9e5570853"
 
-react-router@^3.0.0:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-3.0.2.tgz#5a19156678810e01d81901f9c0fef63284b8a514"
+react-router-dom@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-4.0.0.tgz#4fa4418e14b8cfc5bcc0bdea0c4083fb8c2aef10"
   dependencies:
-    history "^3.0.0"
-    hoist-non-react-statics "^1.2.0"
-    invariant "^2.2.1"
-    loose-envify "^1.2.0"
+    history "^4.5.1"
+    react-router "^4.0.0"
+
+react-router@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-4.0.0.tgz#6532075231f0bb5077c2005c1d417ad6165b3997"
+  dependencies:
+    history "^4.6.0"
+    invariant "^2.2.2"
+    loose-envify "^1.3.1"
+    path-to-regexp "^1.5.3"
     warning "^3.0.0"
 
 react-select@^1.0.0-rc.2:
@@ -3613,6 +3631,10 @@ requires-port@1.0.x, requires-port@1.x.x:
 resolve-from@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
+
+resolve-pathname@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/resolve-pathname/-/resolve-pathname-2.0.2.tgz#e55c016eb2e9df1de98e85002282bfb38c630436"
 
 resolve@^1.1.6:
   version "1.2.0"
@@ -4178,6 +4200,10 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "~1.0.0"
     spdx-expression-parse "~1.0.0"
+
+value-equal@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/value-equal/-/value-equal-0.2.0.tgz#4f41c60a3fc011139a2ec3d3340a8998ae8b69c0"
 
 vary@~1.1.0:
   version "1.1.0"

--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
     "immutable": "^3.8.1",
     "proxyquire": "^1.7.11",
     "react-immutable-proptypes": "^2.1.0",
-    "react-select": "^1.0.0-rc.2"
+    "react-select": "^1.0.0-rc.2",
+    "url-search-params": "^0.7.0"
   },
   "main": "lib/index.js",
   "engines": {

--- a/src/hock/QueryStringHock-test.js
+++ b/src/hock/QueryStringHock-test.js
@@ -362,6 +362,40 @@ test('QueryStringHock should set query for react-router v4 using context.router.
     tt.false(push.called, 'router.push should not be called');
 });
 
+test('QueryStringHock should not change path if path is the same for react-router v4', tt => {
+    const componentToWrap = () => <div>Example Component</div>;
+    const WrappedComponent = QueryStringHock()(componentToWrap);
+    const myWrappedComponent = new WrappedComponent();
+
+    const push = sinon.spy();
+    const replace = sinon.spy();
+
+    const pathname = "PATH";
+
+    myWrappedComponent.context = {
+        router: {
+            history: {
+                push,
+                replace
+            }
+        }
+    };
+    myWrappedComponent.props = {
+        location: {
+            search: "?a=A",
+            pathname
+        }
+    };
+
+    const newQuery = {
+        a: "A"
+    };
+
+    myWrappedComponent.render().props.setQuery(newQuery);
+    tt.false(push.called, 'router.push should not be called');
+    tt.false(replace.called, 'router.replace should not be called');
+});
+
 test('QueryStringHock should not set a query string when no query using react-router v4', tt => {
 
     const componentToWrap = () => <div>Example Component</div>;
@@ -381,7 +415,7 @@ test('QueryStringHock should not set a query string when no query using react-ro
     };
     myWrappedComponent.props = {
         location: {
-            search: "",
+            search: "?old=OLD",
             pathname
         }
     };

--- a/src/hock/QueryStringHock-test.js
+++ b/src/hock/QueryStringHock-test.js
@@ -24,21 +24,24 @@ test('QueryStringHock passes props straight through to children', tt => {
     tt.deepEqual(expectedProps, myWrappedComponent.props);
 });
 
-test('QueryStringHock passes query from react router location prop', tt => {
+test('QueryStringHock passes search from react router location prop', tt => {
 
     const componentToWrap = () => <div>Example Component</div>;
     const WrappedComponent = QueryStringHock()(componentToWrap);
     const myWrappedComponent = new WrappedComponent();
 
-    const query = {
+    myWrappedComponent.props = {
+        location: {
+            search: "?a=A",
+            pathname: "/"
+        }
+    };
+
+    const expectedQuery = {
         a: "A"
     };
 
-    myWrappedComponent.props = {
-        location: {query}
-    };
-
-    tt.deepEqual(myWrappedComponent.render().props.query, query);
+    tt.deepEqual(myWrappedComponent.render().props.query, expectedQuery);
 
 });
 
@@ -62,15 +65,18 @@ test('QueryStringHock should change the name of the query prop if given queryPro
     })(componentToWrap);
     const myWrappedComponent = new WrappedComponent();
 
-    const query = {
+    myWrappedComponent.props = {
+        location: {
+            search: "?a=A",
+            pathname: "/"
+        }
+    };
+
+    const expectedQuery = {
         a: "A"
     };
 
-    myWrappedComponent.props = {
-        location: {query}
-    };
-
-    tt.deepEqual(myWrappedComponent.render().props.coolQueryTime, query);
+    tt.deepEqual(myWrappedComponent.render().props.coolQueryTime, expectedQuery);
 
 });
 
@@ -82,14 +88,11 @@ test('QueryStringHock should convert missing or singular params to array when co
     })(componentToWrap);
     const myWrappedComponent = new WrappedComponent();
 
-    const query = {
-        a: "A",
-        b: ["B", "B2"],
-        d: "D"
-    };
-
     myWrappedComponent.props = {
-        location: {query}
+        location: {
+            search: "?a=A&b=B&b=B2&d=D",
+            pathname: "/"
+        }
     };
 
     const expectedQuery = {
@@ -115,13 +118,11 @@ test('QueryStringHock should use defaultQuery params when not present in query',
     })(componentToWrap);
     const myWrappedComponent = new WrappedComponent();
 
-    const query = {
-        b: "B!",
-        c: ""
-    };
-
     myWrappedComponent.props = {
-        location: {query}
+        location: {
+            search: "?b=B!&c=",
+            pathname: "/"
+        }
     };
 
     const expectedQuery = {
@@ -144,12 +145,11 @@ test('QueryStringHock should set query via history prop for react-router v1 usin
     const replaceState = sinon.spy();
 
     const pathname = "PATH";
-    const query = {};
 
     myWrappedComponent.context = {};
     myWrappedComponent.props = {
         location: {
-            query,
+            search: "",
             pathname
         },
         history: {
@@ -183,12 +183,11 @@ test('QueryStringHock should set query via history prop for react-router v1 usin
     const replaceState = sinon.spy();
 
     const pathname = "PATH";
-    const query = {};
 
     myWrappedComponent.context = {};
     myWrappedComponent.props = {
         location: {
-            query,
+            search: "",
             pathname
         },
         history: {
@@ -210,7 +209,7 @@ test('QueryStringHock should set query via history prop for react-router v1 usin
     tt.false(pushState.called, 'history.pushState should not be called');
 });
 
-test('QueryStringHock should set query via conext.router prop for react-router v2+ using pushState', tt => {
+test('QueryStringHock should set query for react-router v2 and v3 using context.router.push', tt => {
 
     const componentToWrap = () => <div>Example Component</div>;
     const WrappedComponent = QueryStringHock()(componentToWrap);
@@ -220,7 +219,6 @@ test('QueryStringHock should set query via conext.router prop for react-router v
     const replace = sinon.spy();
 
     const pathname = "PATH";
-    const query = {};
 
     myWrappedComponent.context = {
         router: {
@@ -230,7 +228,7 @@ test('QueryStringHock should set query via conext.router prop for react-router v
     };
     myWrappedComponent.props = {
         location: {
-            query,
+            search: "",
             pathname
         }
     };
@@ -246,8 +244,7 @@ test('QueryStringHock should set query via conext.router prop for react-router v
     tt.false(replace.called, 'router.replace should not be called');
 });
 
-
-test('QueryStringHock should set query via conext.router prop for react-router v2+ using replaceState', tt => {
+test('QueryStringHock should set query for react-router v2 and v3 using context.router.replace', tt => {
 
     const componentToWrap = () => <div>Example Component</div>;
     const WrappedComponent = QueryStringHock({
@@ -259,7 +256,6 @@ test('QueryStringHock should set query via conext.router prop for react-router v
     const replace = sinon.spy();
 
     const pathname = "PATH";
-    const query = {};
 
     myWrappedComponent.context = {
         router: {
@@ -269,7 +265,7 @@ test('QueryStringHock should set query via conext.router prop for react-router v
     };
     myWrappedComponent.props = {
         location: {
-            query,
+            search: "",
             pathname
         }
     };
@@ -285,6 +281,119 @@ test('QueryStringHock should set query via conext.router prop for react-router v
     tt.false(push.called, 'router.push should not be called');
 });
 
+
+test('QueryStringHock should set query for react-router v4 using context.router.history.push', tt => {
+
+    const componentToWrap = () => <div>Example Component</div>;
+    const WrappedComponent = QueryStringHock()(componentToWrap);
+    const myWrappedComponent = new WrappedComponent();
+
+    const push = sinon.spy();
+    const replace = sinon.spy();
+
+    const pathname = "PATH";
+
+    myWrappedComponent.context = {
+        router: {
+            history: {
+                push,
+                replace
+            }
+        }
+    };
+    myWrappedComponent.props = {
+        location: {
+            search: "",
+            pathname
+        }
+    };
+
+    const newQuery = {
+        a: "A"
+    };
+
+    const newPathname = `${pathname}?a=A`;
+
+    myWrappedComponent.render().props.setQuery(newQuery);
+
+    tt.true(push.calledOnce, 'router.push is called');
+    tt.is(push.firstCall.args[0], newPathname, 'First arg should contain new pathname');
+    tt.false(replace.called, 'router.replace should not be called');
+});
+
+test('QueryStringHock should set query for react-router v4 using context.router.history.replace', tt => {
+
+    const componentToWrap = () => <div>Example Component</div>;
+    const WrappedComponent = QueryStringHock({
+        replaceState: true
+    })(componentToWrap);
+    const myWrappedComponent = new WrappedComponent();
+
+    const push = sinon.spy();
+    const replace = sinon.spy();
+
+    const pathname = "PATH";
+
+    myWrappedComponent.context = {
+        router: {
+            history: {
+                push,
+                replace
+            }
+        }
+    };
+    myWrappedComponent.props = {
+        location: {
+            search: "",
+            pathname
+        }
+    };
+
+    const newQuery = {
+        a: "A"
+    };
+
+    const newPathname = `${pathname}?a=A`;
+
+    myWrappedComponent.render().props.setQuery(newQuery);
+
+    tt.true(replace.calledOnce, 'router.replace is called');
+    tt.is(replace.firstCall.args[0], newPathname, 'First arg should contain new pathname');
+    tt.false(push.called, 'router.push should not be called');
+});
+
+test('QueryStringHock should not set a query string for react-router v4', tt => {
+
+    const componentToWrap = () => <div>Example Component</div>;
+    const WrappedComponent = QueryStringHock()(componentToWrap);
+    const myWrappedComponent = new WrappedComponent();
+
+    const push = sinon.spy();
+
+    const pathname = "PATH";
+
+    myWrappedComponent.context = {
+        router: {
+            history: {
+                push
+            }
+        }
+    };
+    myWrappedComponent.props = {
+        location: {
+            search: "",
+            pathname
+        }
+    };
+
+    const newQuery = {};
+
+    myWrappedComponent.render().props.setQuery(newQuery);
+
+    tt.true(push.calledOnce, 'router.push is called');
+    tt.is(push.firstCall.args[0], pathname, 'First arg should contain new pathname');
+});
+
 test('QueryStringHock setQuery should replace existing query completely', tt => {
 
     const componentToWrap = () => <div>Example Component</div>;
@@ -293,11 +402,6 @@ test('QueryStringHock setQuery should replace existing query completely', tt => 
 
     const push = sinon.spy();
 
-    const query = {
-        c: "C",
-        d: "D"
-    };
-
     myWrappedComponent.context = {
         router: {
             push
@@ -305,7 +409,8 @@ test('QueryStringHock setQuery should replace existing query completely', tt => 
     };
     myWrappedComponent.props = {
         location: {
-            query
+            search: "?c=C&d=D",
+            pathname: '/'
         }
     };
 
@@ -333,7 +438,7 @@ test('QueryStringHock setQuery should replace pathname if provided as a param', 
     };
     myWrappedComponent.props = {
         location: {
-            query: {foo: 'bar'},
+            search: "?foo=bar",
             pathname: '/'
         }
     };
@@ -377,8 +482,6 @@ test('QueryStringHock setQuery should filter out empty strings and nulls', tt =>
 
     const push = sinon.spy();
 
-    const query = {};
-
     myWrappedComponent.context = {
         router: {
             push
@@ -386,7 +489,8 @@ test('QueryStringHock setQuery should filter out empty strings and nulls', tt =>
     };
     myWrappedComponent.props = {
         location: {
-            query
+            search: "",
+            pathname: '/'
         }
     };
 
@@ -416,10 +520,6 @@ test('QueryStringHock updateQuery should merge with existing query', tt => {
     const push = sinon.spy();
 
     const pathname = "PATH";
-    const query = {
-        c: "C",
-        d: "D"
-    };
 
     myWrappedComponent.context = {
         router: {
@@ -428,7 +528,7 @@ test('QueryStringHock updateQuery should merge with existing query', tt => {
     };
     myWrappedComponent.props = {
         location: {
-            query,
+            search: "?c=C&d=D",
             pathname
         }
     };
@@ -485,11 +585,6 @@ test('QueryStringHock updateQuery should filter out empty strings and nulls', tt
 
     const push = sinon.spy();
 
-    const query = {
-        b: "B",
-        c: "C"
-    };
-
     myWrappedComponent.context = {
         router: {
             push
@@ -497,7 +592,8 @@ test('QueryStringHock updateQuery should filter out empty strings and nulls', tt
     };
     myWrappedComponent.props = {
         location: {
-            query
+            search: "?b=B&c=C",
+            pathname: '/'
         }
     };
 
@@ -538,14 +634,17 @@ test('QueryStringHock updateQuery can cope with merging and not merging array pa
 
     const push = sinon.spy();
 
-    const query = {
-        oneToNone: "one",
-        oneToOne: "one",
-        oneToTwo: "one",
-        twoToNone: ["1", "2"],
-        twoToOne: ["1", "2"],
-        twoToTwo: ["1", "2"]
-    };
+    const search = "?"+[
+        "oneToNone=one",
+        "oneToOne=one",
+        "oneToTwo=one",
+        "twoToNone=1",
+        "twoToOne=1",
+        "twoToTwo=1",
+        "twoToNone=2",
+        "twoToOne=2",
+        "twoToTwo=2"
+    ].join("&");
 
     myWrappedComponent.context = {
         router: {
@@ -554,7 +653,8 @@ test('QueryStringHock updateQuery can cope with merging and not merging array pa
     };
     myWrappedComponent.props = {
         location: {
-            query
+            search,
+            pathname: '/'
         }
     };
 
@@ -598,7 +698,7 @@ test('QueryStringHock updateQuery should replace pathname if provided as a param
     };
     myWrappedComponent.props = {
         location: {
-            query: {foo: 'bar'},
+            search: "?foo=bar",
             pathname: '/'
         }
     };

--- a/src/hock/QueryStringHock-test.js
+++ b/src/hock/QueryStringHock-test.js
@@ -362,7 +362,7 @@ test('QueryStringHock should set query for react-router v4 using context.router.
     tt.false(push.called, 'router.push should not be called');
 });
 
-test('QueryStringHock should not set a query string for react-router v4', tt => {
+test('QueryStringHock should not set a query string when no query using react-router v4', tt => {
 
     const componentToWrap = () => <div>Example Component</div>;
     const WrappedComponent = QueryStringHock()(componentToWrap);
@@ -392,6 +392,43 @@ test('QueryStringHock should not set a query string for react-router v4', tt => 
 
     tt.true(push.calledOnce, 'router.push is called');
     tt.is(push.firstCall.args[0], pathname, 'First arg should contain new pathname');
+});
+
+test('QueryStringHock should stringify array params correctly using react-router v4', tt => {
+
+    const componentToWrap = () => <div>Example Component</div>;
+    const WrappedComponent = QueryStringHock()(componentToWrap);
+    const myWrappedComponent = new WrappedComponent();
+
+    const push = sinon.spy();
+
+    const pathname = "PATH";
+
+    myWrappedComponent.context = {
+        router: {
+            history: {
+                push
+            }
+        }
+    };
+    myWrappedComponent.props = {
+        location: {
+            search: "",
+            pathname
+        }
+    };
+
+    const newQuery = {
+        a: ["A", "B", "C"],
+        z: "Z"
+    };
+
+    myWrappedComponent.render().props.setQuery(newQuery);
+
+    const newPathname = `${pathname}?a=A&a=B&a=C&z=Z`;
+
+    tt.true(push.calledOnce, 'router.push is called');
+    tt.is(push.firstCall.args[0], newPathname, 'First arg should contain new pathname');
 });
 
 test('QueryStringHock setQuery should replace existing query completely', tt => {

--- a/src/hock/QueryStringHock.jsx
+++ b/src/hock/QueryStringHock.jsx
@@ -70,7 +70,7 @@ export default (config: ?Object = null): HockApplier => {
          * @decorator {QueryStringHock}
          *
          * @prop {Object} location
-         * Required for `react-router` v1, v2, v2 and v4. Must be react router location object.
+         * Required for `react-router` v1, v2, v3 and v4. Must be react router location object.
          *
          * @prop {Object} history
          * Required only for `react-router` v1. Must be react router history object.

--- a/src/hock/QueryStringHock.jsx
+++ b/src/hock/QueryStringHock.jsx
@@ -224,7 +224,7 @@ export default (config: ?Object = null): HockApplier => {
                 }
 
                 // only set new pathname if it has changed
-                if(newPath != this.props.location.pathname + this.props.location.search) {
+                if(newPath !== this.props.location.pathname + this.props.location.search) {
                     this.context.router.history[routerMethod](newPath);
                 }
             }

--- a/src/hock/QueryStringHock.jsx
+++ b/src/hock/QueryStringHock.jsx
@@ -2,6 +2,7 @@
 
 import React, {Component, PropTypes} from 'react';
 import {fromJS, List, Map} from 'immutable';
+import URLSearchParams from 'url-search-params';
 
 /**
  * @module Hocks
@@ -13,14 +14,24 @@ export default (config: ?Object = null): HockApplier => {
         const replaceState: boolean = !!(config && config.replaceState);
         const queryPropName: string = (config && config.queryPropName) || "query";
         const arrayParams: List<string> = (config && fromJS(config.arrayParams)) || List();
-        const defaultQuery: Map<string,any> = (config && fromJS(config.defaultQuery)) || Map();
+
+        // default all array params to empty lists
+        const defaultArrayParams: Map<string, List<string>> = arrayParams
+            .reduce((defaultQuery: Map<string, List<string>>, arrayParam: string) => {
+                return defaultQuery.set(arrayParam, List());
+            }, Map())
+
+        // default query is comprised of the default array param lists,
+        // with config.defaultQuery merged on top of it
+        const defaultQuery: Map<string,any> = defaultArrayParams
+            .merge((config && fromJS(config.defaultQuery)) || Map());
 
         /**
          * @component
          *
          * `QueryStringHock` is a higher order component designed to greatly simplify getting
          * and setting the query string, if your app is using `react-router`
-         * (currently works with v1.x and v2.x).  When used on a component, your component will
+         * (currently works with v1, v2, v3 and v4).  When used on a component, your component will
          * receive some extra props.
          *
          * It also allows for array parameters, push state vs replace state,
@@ -32,7 +43,8 @@ export default (config: ?Object = null): HockApplier => {
          * are passed straight to a <Route> object.
          * If you're using `react-router` v1 then you'll also need to pass it a history prop
          * that `react-router` provides.
-         * If using `react-router` v2 then QueryStringHock will automatically connect via context.
+         * If using `react-router` v2 or greater then QueryStringHock will automatically
+         * receive this via context.
          *
          * @example
          * function MyComponent(props) {
@@ -58,12 +70,12 @@ export default (config: ?Object = null): HockApplier => {
          * @decorator {QueryStringHock}
          *
          * @prop {Object} location
-         * Required for `react-router` v1 and v2. Must be react router location object.
+         * Required for `react-router` v1, v2, v2 and v4. Must be react router location object.
          *
          * @prop {Object} history
          * Required only for `react-router` v1. Must be react router history object.
          *
-         * @context {Object} router Required for `react-router` v2,
+         * @context {Object} router Required for `react-router` v2, v3 and v4
          * where it should be provided automatically.
          *
          * @childprop {Object} query The object representing the query string.
@@ -94,23 +106,33 @@ export default (config: ?Object = null): HockApplier => {
              * @param {Object} props Props to refer to.
              */
 
-            getQuery(props: Object): Object {
-                if(!props.location || !props.location.query) {
-                    return {};
+            getQuery(): Map<string, string|Array<string>> {
+                if(!this.props.location || !this.props.location.search) {
+                    return Map();
                 }
-                const existingQuery: Object = props.location.query;
-                const query: Map<string,any> = defaultQuery.merge(
-                    fromJS(existingQuery).filter(ii => ii != "")
-                );
 
-                // ensures that all arrayParams are returned as arrays (not strings or blank)
-                return arrayParams
-                    .reduce((query, arrayParamKey) => {
-                        const param = query.get(arrayParamKey, List());
-                        const arrayParamValue = List.isList(param) ? param : List([param]);
-                        return query.set(arrayParamKey, arrayParamValue);
-                    }, query)
-                    .toJS();
+                const searchParams: URLSearchParams = new URLSearchParams(this.props.location.search);
+
+                var params: Array<Array<string>>= [];
+                for(let param of searchParams) {
+                    params.push(param);
+                }
+                const groupedParams: Map<string,any> = fromJS(params)
+                    .filter(ii => ii.get(1) != "")
+                    .groupBy(ii => ii.get(0))
+                    .toMap()
+                    .map(param => param.map(ii => ii.get(1)))
+                    .map((value, key) => {
+                        // if an array param, return list as is
+                        if(arrayParams.contains(key)) {
+                            return value;
+                        }
+                        // if not an array param, use the value of the first param with this key
+                        return value.get(0);
+                    });
+
+                return defaultQuery
+                    .merge(groupedParams);
             }
 
             /**
@@ -128,12 +150,7 @@ export default (config: ?Object = null): HockApplier => {
              */
 
             updateQuery(queryParamsToUpdate: Object, pathname?: string) {
-                if(!this.props.location || !this.props.location.query) {
-                    console.warn("Cannot call updateQuery, QueryStringHock has not been given a react-router location.query prop");
-                    return;
-                }
-                const existingQuery: Object = this.props.location.query;
-                const query = fromJS(existingQuery)
+                const query = this.getQuery()
                     .merge(fromJS(queryParamsToUpdate))
                     .toJS();
                 this.setQuery(query, pathname);
@@ -153,34 +170,64 @@ export default (config: ?Object = null): HockApplier => {
              */
 
             setQuery(query: Object, pathname?: string) {
-                if(!this.props.location || !this.props.location.query) {
-                    console.warn("Cannot call setQuery, QueryStringHock has not been given a react-router location.query prop");
+                if(!this.props.location || !this.props.location.pathname) {
+                    console.warn("Cannot call setQuery, QueryStringHock has not been given a react-router location.pathname prop");
                     return;
                 }
+
+                if(!pathname) {
+                    pathname = this.props.location.pathname;
+                }
+
                 const routerMethod: string = replaceState ? "replace" : "push";
                 const newQuery: Object = fromJS(query)
-                    .filter(ii => ii !== "" && ii != null) // non strict null comparison to catch undefined & null
-                    .toJS();
+                    .filter(ii => ii !== "" && ii != null); // non strict null comparison to catch undefined & null
 
-                if(this.context.router) {
-                    // react router v2
-                    this.context.router[routerMethod]({
-                        pathname: pathname || this.props.location.pathname,
-                        query: newQuery
-                    });
-                } else {
+                if(!this.context.router) {
                     // react router v1
                     this.props.history[`${routerMethod}State`](
                         null,
-                        pathname || this.props.location.pathname,
-                        newQuery
+                        pathname,
+                        newQuery.toJS()
                     );
+                    return;
                 }
+
+                if(!this.context.router.history) {
+                    // react router v2 and v3
+                    this.context.router[routerMethod]({
+                        pathname,
+                        query: newQuery.toJS()
+                    });
+                    return;
+                }
+
+                // react router v4
+                var newPath = pathname;
+                if(!newQuery.isEmpty()) {
+
+                    // build query string
+                    const newQueryString: string = newQuery
+                        .reduce((list: List<string>, value: string|List<string>, key: string): List<string> => {
+                            if(List.isList(value)) {
+                                return list.concat(
+                                    // $FlowFixMe: flow doesnt seem to know that List.isList() returns false for strings
+                                    value.map(ii => `${key}=${ii}`)
+                                );
+                            }
+                            // $FlowFixMe: flow doesnt seem to know that List.isList() returns false for strings
+                            return list.push(`${key}=${value}`);
+                        }, List())
+                        .join("&")
+
+                    newPath += `?${newQueryString}`;
+                }
+                this.context.router.history[routerMethod](newPath);
             }
 
             render(): React.Element<any> {
                 const newProps: Object = {
-                    [queryPropName]: this.getQuery(this.props),
+                    [queryPropName]: this.getQuery().toJS(), // TODO memoize this!
                     setQuery: this.setQuery,
                     updateQuery: this.updateQuery
                 };

--- a/src/hock/QueryStringHock.jsx
+++ b/src/hock/QueryStringHock.jsx
@@ -222,7 +222,11 @@ export default (config: ?Object = null): HockApplier => {
 
                     newPath += `?${newQueryString}`;
                 }
-                this.context.router.history[routerMethod](newPath);
+
+                // only set new pathname if it has changed
+                if(newPath != this.props.location.pathname + this.props.location.search) {
+                    this.context.router.history[routerMethod](newPath);
+                }
             }
 
             render(): React.Element<any> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -441,15 +441,6 @@ babel-helper-builder-react-jsx@^6.8.0:
     esutils "^2.0.0"
     lodash "^4.2.0"
 
-babel-helper-call-delegate@^6.18.0:
-  version "6.18.0"
-  resolved "https://registry.yarnpkg.com/babel-helper-call-delegate/-/babel-helper-call-delegate-6.18.0.tgz#05b14aafa430884b034097ef29e9f067ea4133bd"
-  dependencies:
-    babel-helper-hoist-variables "^6.18.0"
-    babel-runtime "^6.0.0"
-    babel-traverse "^6.18.0"
-    babel-types "^6.18.0"
-
 babel-helper-call-delegate@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-helper-call-delegate/-/babel-helper-call-delegate-6.22.0.tgz#119921b56120f17e9dae3f74b4f5cc7bcc1b37ef"
@@ -765,18 +756,7 @@ babel-plugin-transform-es2015-object-super@^6.3.13:
     babel-helper-replace-supers "^6.8.0"
     babel-runtime "^6.0.0"
 
-babel-plugin-transform-es2015-parameters@^6.18.0:
-  version "6.18.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.18.0.tgz#9b2cfe238c549f1635ba27fc1daa858be70608b1"
-  dependencies:
-    babel-helper-call-delegate "^6.18.0"
-    babel-helper-get-function-arity "^6.18.0"
-    babel-runtime "^6.9.0"
-    babel-template "^6.16.0"
-    babel-traverse "^6.18.0"
-    babel-types "^6.18.0"
-
-babel-plugin-transform-es2015-parameters@^6.21.0:
+babel-plugin-transform-es2015-parameters@^6.18.0, babel-plugin-transform-es2015-parameters@^6.21.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.23.0.tgz#3a2aabb70c8af945d5ce386f1a4250625a83ae3b"
   dependencies:
@@ -960,37 +940,37 @@ babel-register@^6.18.0:
     mkdirp "^0.5.1"
     source-map-support "^0.4.2"
 
-babel-runtime@^6.0.0, babel-runtime@^6.11.6, babel-runtime@^6.18.0, babel-runtime@^6.20.0, babel-runtime@^6.5.0, babel-runtime@^6.9.0, babel-runtime@^6.9.1:
+babel-runtime@^6.0.0, babel-runtime@^6.11.6, babel-runtime@^6.20.0, babel-runtime@^6.5.0, babel-runtime@^6.9.0, babel-runtime@^6.9.1:
   version "6.20.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.20.0.tgz#87300bdcf4cd770f09bf0048c64204e17806d16f"
   dependencies:
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
 
-babel-runtime@^6.22.0:
+babel-runtime@^6.18.0, babel-runtime@^6.22.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.23.0.tgz#0a9489f144de70efb3ce4300accdb329e2fc543b"
   dependencies:
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
 
-babel-template@^6.14.0, babel-template@^6.15.0, babel-template@^6.16.0, babel-template@^6.8.0:
-  version "6.16.0"
-  resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.16.0.tgz#e149dd1a9f03a35f817ddbc4d0481988e7ebc8ca"
-  dependencies:
-    babel-runtime "^6.9.0"
-    babel-traverse "^6.16.0"
-    babel-types "^6.16.0"
-    babylon "^6.11.0"
-    lodash "^4.2.0"
-
-babel-template@^6.23.0, babel-template@^6.7.0:
+babel-template@^6.14.0, babel-template@^6.23.0, babel-template@^6.7.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.23.0.tgz#04d4f270adbb3aa704a8143ae26faa529238e638"
   dependencies:
     babel-runtime "^6.22.0"
     babel-traverse "^6.23.0"
     babel-types "^6.23.0"
+    babylon "^6.11.0"
+    lodash "^4.2.0"
+
+babel-template@^6.15.0, babel-template@^6.16.0, babel-template@^6.8.0:
+  version "6.16.0"
+  resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.16.0.tgz#e149dd1a9f03a35f817ddbc4d0481988e7ebc8ca"
+  dependencies:
+    babel-runtime "^6.9.0"
+    babel-traverse "^6.16.0"
+    babel-types "^6.16.0"
     babylon "^6.11.0"
     lodash "^4.2.0"
 
@@ -1022,7 +1002,7 @@ babel-traverse@^6.22.0, babel-traverse@^6.23.0:
     invariant "^2.2.0"
     lodash "^4.2.0"
 
-babel-types@^6.0.19, babel-types@^6.16.0, babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.20.0, babel-types@^6.8.0, babel-types@^6.9.0:
+babel-types@^6.0.19, babel-types@^6.16.0, babel-types@^6.18.0, babel-types@^6.20.0, babel-types@^6.9.0:
   version "6.20.0"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.20.0.tgz#3869ecb98459533b37df809886b3f7f3b08d2baa"
   dependencies:
@@ -1031,7 +1011,7 @@ babel-types@^6.0.19, babel-types@^6.16.0, babel-types@^6.18.0, babel-types@^6.19
     lodash "^4.2.0"
     to-fast-properties "^1.0.1"
 
-babel-types@^6.22.0, babel-types@^6.23.0, babel-types@^6.7.2:
+babel-types@^6.19.0, babel-types@^6.22.0, babel-types@^6.23.0, babel-types@^6.7.2, babel-types@^6.8.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.23.0.tgz#bb17179d7538bad38cd0c9e115d340f77e7e9acf"
   dependencies:
@@ -4772,6 +4752,10 @@ url-parse-lax@^1.0.0:
   resolved "https://registry.yarnpkg.com/url-parse-lax/-/url-parse-lax-1.0.0.tgz#7af8f303645e9bd79a272e7a14ac68bc0609da73"
   dependencies:
     prepend-http "^1.0.1"
+
+url-search-params@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/url-search-params/-/url-search-params-0.7.0.tgz#2545d3425d81ed3c903a213a501edb7d6ddd1be9"
 
 url2@^0.0.0:
   version "0.0.0"


### PR DESCRIPTION
- Switch from using `props.location.query` to `prrops.location.search` for all versions of react router.
- Add ability to set query for react router 4
- Add query string parsing with a polyfilled version of URLSearchParams
- Upgrade to react router 4 on example pages
- Add example for query string provider
- Add and modify tests / ensure 100% coverage / linting
- Update docs a tad