### PR TITLE
Feature/speed up split index pipe

### DIFF
--- a/src/hock/QueryStringHock.jsx
+++ b/src/hock/QueryStringHock.jsx
@@ -101,7 +101,7 @@ export default (config: ?Object = null): HockApplier => {
                 this.setQuery = this.setQuery.bind(this);
             }
 
-            /**
+            /*
              * Gets the query object
              * @param {Object} props Props to refer to.
              */
@@ -135,7 +135,7 @@ export default (config: ?Object = null): HockApplier => {
                     .merge(groupedParams);
             }
 
-            /**
+            /*
              * Partially updates the query.
              * Any keys on the objects passed in will be modified on the query object.
              * Keys set to empty strings or `null` will be removed from the query object.
@@ -156,7 +156,7 @@ export default (config: ?Object = null): HockApplier => {
                 this.setQuery(query, pathname);
             }
 
-            /**
+            /*
              * Replaces the current query string with the params defined in `query`.
              * Keys set to empty strings or `null` will be removed from the query object.
              *

--- a/src/pipe/SplitIndexPipe-test.js
+++ b/src/pipe/SplitIndexPipe-test.js
@@ -259,6 +259,29 @@ test('SplitIndexPipe should update childProps on componentWillReceiveProps if co
     );
 });
 
+test('SplitIndexPipe should not update partial onChange functions if there is no reason to', tt => {
+    const componentToWrap = () => <div>Example Component</div>;
+    const WrappedComponent = SplitIndexPipe()(componentToWrap);
+
+    const anotherWrappedComponent = new WrappedComponent({
+        value: [1,2,3]
+    });
+
+    const firstOnChange = anotherWrappedComponent.render().props.split[0].onChange;
+
+    const nextProps = {
+        value: [1,2,3]
+    };
+
+    anotherWrappedComponent.componentWillReceiveProps(nextProps);
+    anotherWrappedComponent.props = nextProps;
+
+    tt.is(
+        firstOnChange,
+        anotherWrappedComponent.render().props.split[0].onChange
+    );
+});
+
 test('SplitIndexPipe can set config.splitProp', tt => {
     const componentToWrap = () => <div>Example Component</div>;
     const WrappedComponent = SplitIndexPipe(() => ({
@@ -286,6 +309,8 @@ test('SplitIndexPipe has a default config for valueChangePairs', tt => {
     tt.is(split[0].value, "Tom", 'value is included in default valueChangePairs');
     tt.is(typeof split[0].onChange, "function", 'onChange is included in default valueChangePairs');
 });
+
+
 
 //
 // static methods

--- a/src/pipe/SplitKeyPipe.jsx
+++ b/src/pipe/SplitKeyPipe.jsx
@@ -159,7 +159,7 @@ export default ConfigureHock(
                     changeFunction(updatedValue);
                 };
 
-                // memoize the onCHange functions of a maximum of 100 different keys
+                // memoize the onChange functions of a maximum of 100 different keys
                 createPartialChangeMemoized: Function = memoize(100)(this.createPartialChange);
 
                 render(): React.Element<any> {

--- a/src/pipe/SplitKeyPipe.jsx
+++ b/src/pipe/SplitKeyPipe.jsx
@@ -140,8 +140,8 @@ export default ConfigureHock(
 
                             return {
                                 ...obj,
-                                [valueChangeProp.get('valueName')]: value,
-                                [valueChangeProp.get('onChangeName')]: onChange
+                                [valueName]: value,
+                                [onChangeName]: onChange
                             };
                         }, {});
                 };
@@ -159,7 +159,8 @@ export default ConfigureHock(
                     changeFunction(updatedValue);
                 };
 
-                createPartialChangeMemoized: Function = memoize()(this.createPartialChange);
+                // memoize the onCHange functions of a maximum of 100 different keys
+                createPartialChangeMemoized: Function = memoize(100)(this.createPartialChange);
 
                 render(): React.Element<any> {
                     var newProps: Object = Object.assign({}, this.props, this.childProps);

--- a/src/util/SpruceComponent-test.js
+++ b/src/util/SpruceComponent-test.js
@@ -18,7 +18,6 @@ test('the component renders the given type', tt => {
 });
 
 test('the component renders SpruceClassNames', tt => {
-    console.log(fooWrapper);
     tt.is(fooWrapper.hasClass('Foo'), true);
     tt.is(fooWrapper.hasClass('Foo-red'), true);
     tt.is(fooWrapper.hasClass('Foo--Button'), true);


### PR DESCRIPTION
- Memoize onChange functions created by split index pipe
- Allow onChange memoization to work on multiple keys
- Remove unnecesary console.log in test
- Make method docs not show up in generated docs