### PR TITLE
Add ismounted check to element query hock

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "bruce": "^0.9.0",
     "classnames": "^2.2.5",
     "debounce": "^1.0.2",
-    "element-resize-detector": "^1.1.9",
+    "element-resize-detector": "^1.1.12",
     "immutable": "^3.8.1",
     "is-plain-object": "^2.0.3",
     "lru-memoize": "^1.0.2",

--- a/src/hock/ElementQueryHock-test.js
+++ b/src/hock/ElementQueryHock-test.js
@@ -98,6 +98,7 @@ test('ElementQueryHock', tt => {
 
     const HockInstance = new ElementQueryHockExample();
     HockInstance.setState = sinon.spy(function() {});
+    HockInstance.mounted = true;
 
     HockInstance.state = {width: 300, height: 600}; // manually set state cos react won't do it without a mounted component
     HockInstance.handleResize({clientWidth: 300, clientHeight: 600});

--- a/src/hock/ElementQueryHock-test.js
+++ b/src/hock/ElementQueryHock-test.js
@@ -114,4 +114,14 @@ test('ElementQueryHock', tt => {
         'doesn\'t call set state if neither width nor height changes'
     );
 
+    HockInstance.mounted = false;
+    HockInstance.handleResize();
+
+    tt.is(
+        HockInstance.setState.callCount,
+        1,
+        'exits early if mouted is false'
+    );
+
 });
+

--- a/src/hock/ElementQueryHock.jsx
+++ b/src/hock/ElementQueryHock.jsx
@@ -125,6 +125,10 @@ const ElementQueryDecorator = (eqs: ElementQuery[]): HockApplier => {
             }
 
             handleResize(element: HTMLElement) {
+                if(!this.mounted) {
+                    return;
+                }
+
                 // This method uses native es3 js functionality for (admittedly minute) performance
                 // improvements. Seeing as this method is called alotta times it is (probably) worth it
                 var width = element.clientWidth;
@@ -144,9 +148,7 @@ const ElementQueryDecorator = (eqs: ElementQuery[]): HockApplier => {
                     }
                 }
 
-                if(this.mounted) {
-                    this.setState({width, height, active, inactive, ready: true});
-                }
+                this.setState({width, height, active, inactive, ready: true});
             }
 
             render(): React.Element<any> {

--- a/src/hock/ElementQueryHock.jsx
+++ b/src/hock/ElementQueryHock.jsx
@@ -8,7 +8,7 @@ type ElementQuery = {
     name: string,
     widthBounds: number[],
     heightBounds: number[]
-}
+};
 
 type ElementQueryHockProps = {
     eqWidth: number,
@@ -16,7 +16,7 @@ type ElementQueryHockProps = {
     eqActive: string[],
     eqInactive: string[],
     eqReady: boolean
-}
+};
 
 let erd = null;
 if(typeof window !== 'undefined') { // Don't try to detect resize events on server
@@ -85,16 +85,19 @@ const ElementQueryDecorator = (eqs: ElementQuery[]): HockApplier => {
         class ElementQueryHock extends Component {
             handleResize: Function;
             state: Object;
+            mounted: boolean;
 
             constructor(props: ElementQueryHockProps) {
                 super(props);
                 this.handleResize = this.handleResize.bind(this);
+                this.mounted = false;
                 this.state = {
                     ready: false
                 };
             }
 
             componentDidMount() {
+                this.mounted = true;
                 if(erd) {
                     const container = findDOMNode(this).parentNode;
                     erd.listenTo(container, this.handleResize);
@@ -103,6 +106,7 @@ const ElementQueryDecorator = (eqs: ElementQuery[]): HockApplier => {
             }
 
             componentWillUnmount() {
+                this.mounted = false;
                 if(erd) {
                     erd.removeListener(findDOMNode(this).parentNode, this.handleResize);
                 }
@@ -140,7 +144,9 @@ const ElementQueryDecorator = (eqs: ElementQuery[]): HockApplier => {
                     }
                 }
 
-                this.setState({width, height, active, inactive, ready: true});
+                if(this.mounted) {
+                    this.setState({width, height, active, inactive, ready: true});
+                }
             }
 
             render(): React.Element<any> {

--- a/src/hock/ElementQueryHockServerSide-test.js
+++ b/src/hock/ElementQueryHockServerSide-test.js
@@ -34,6 +34,6 @@ test('ElementQueryHockServerSide', tt => {
 
     const HockInstance = new ElementQueryHockExample();
 
-    tt.notThrows(HockInstance.componentDidMount, 'Doesn\'t throw errors when mounting without window global');
-    tt.notThrows(HockInstance.componentWillUnmount, 'Doesn\'t throw errors when unmounting without window global');
+    tt.notThrows(() => HockInstance.componentDidMount(), 'Doesn\'t throw errors when mounting without window global');
+    tt.notThrows(() => HockInstance.componentWillUnmount(), 'Doesn\'t throw errors when unmounting without window global');
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1839,9 +1839,9 @@ ecc-jsbn@~0.1.1:
   dependencies:
     jsbn "~0.1.0"
 
-element-resize-detector@^1.1.9:
-  version "1.1.10"
-  resolved "https://registry.yarnpkg.com/element-resize-detector/-/element-resize-detector-1.1.10.tgz#512ca38e1a27b3f6582a83ea0dfed1ba1abab56d"
+element-resize-detector@^1.1.12:
+  version "1.1.12"
+  resolved "https://registry.yarnpkg.com/element-resize-detector/-/element-resize-detector-1.1.12.tgz#8b3fd6eedda17f9c00b360a0ea2df9927ae80ba2"
   dependencies:
     batch-processor "^1.0.0"
 


### PR DESCRIPTION
element-resize-detector seems to be firing the resize event after it has been removed.