### PR TITLE
Make ToggleSet options[].value less strict

### DIFF
--- a/src/input/toggleSet/ToggleSet.jsx
+++ b/src/input/toggleSet/ToggleSet.jsx
@@ -148,7 +148,7 @@ ToggleSet.propTypes = {
     /** The options that the user can select. Each will appear as a toggle. */
     options: PropTypes.arrayOf(
         PropTypes.shape({
-            value: PropTypes.string,
+            value: PropTypes.any.isRequired,
             label: PropTypes.string
         })
     ).isRequired,


### PR DESCRIPTION
As the selection is an Immutable set, it can be way looser about
the types it accepts