### PR TITLE
Feature/upgrade unmutable

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "classnames": "^2.2.5",
     "element-resize-detector": "^1.1.12",
     "is-plain-object": "^2.0.3",
-    "unmutable": "^0.29.2",
+    "unmutable": "^0.34.0",
     "url-search-params": "^0.9.0"
   },
   "main": "lib/index.js",

--- a/src/deprecated/util/__test__/CollectionUtils-test.js
+++ b/src/deprecated/util/__test__/CollectionUtils-test.js
@@ -6,11 +6,11 @@ test('isKeyed() works', tt => {
     tt.true(isKeyed({}));
     tt.true(isKeyed(Map()));
     tt.true(isKeyed(OrderedMap()));
+    tt.true(isKeyed(() => {}));
 
     tt.false(isKeyed());
     tt.false(isKeyed(1));
     tt.false(isKeyed(null));
-    tt.false(isKeyed(() => {}));
     tt.false(isKeyed([]));
     tt.false(isKeyed(List()));
     tt.false(isKeyed(Stack()));

--- a/src/hock/PropChangeHock.jsx
+++ b/src/hock/PropChangeHock.jsx
@@ -2,9 +2,9 @@
 
 import React from 'react';
 import type {ComponentType, Element} from 'react';
-import {is} from 'immutable';
 import ConfigureHock from '../deprecated/util/ConfigureHock';
 import getIn from 'unmutable/lib/getIn';
+import equals from 'unmutable/lib/equals';
 
 /**
  * @module Hocks
@@ -60,10 +60,7 @@ export default ConfigureHock(
                             const keyPath = ii.split('.');
                             const getKeyPath = getIn(keyPath);
 
-                            return !is(
-                                getKeyPath(this.props),
-                                getKeyPath(nextProps)
-                            );
+                            return !equals(getKeyPath(this.props))(getKeyPath(nextProps));
                         });
 
                     if(propsHaveChanged) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4167,6 +4167,10 @@ lodash.pick@^4.2.1:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
 
+lodash.range@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.range/-/lodash.range-3.2.0.tgz#f461e588f66683f7eadeade513e38a69a565a15d"
+
 lodash.reduce@^4.4.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.reduce/-/lodash.reduce-4.6.0.tgz#f1ab6b839299ad48f784abbf476596f03b914d3b"
@@ -6006,12 +6010,13 @@ universalify@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.1.tgz#fa71badd4437af4c148841e3b3b165f9e9e590b7"
 
-unmutable@^0.29.2:
-  version "0.29.2"
-  resolved "https://registry.yarnpkg.com/unmutable/-/unmutable-0.29.2.tgz#8463a104c7088e13c5b958131c14fa2bd01ae65f"
+unmutable@^0.34.0:
+  version "0.34.0"
+  resolved "https://registry.yarnpkg.com/unmutable/-/unmutable-0.34.0.tgz#512ad3f5286215cab8ce554741d42c2ca8822a70"
   dependencies:
     fast-deep-equal "^1.0.0"
     is-plain-object "^2.0.4"
+    lodash.range "^3.2.0"
 
 unset-value@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
- Upgrade unmutable
  - Class instances and functions can now be used in the keyPaths of PropChangeHock
- Change deprecated isKeyed method to align with better decisions in unmutable
- Remove immutable dependency from stampy