### PR TITLE
Use latest unmutable

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "classnames": "^2.2.5",
     "element-resize-detector": "^1.1.12",
     "is-plain-object": "^2.0.3",
-    "unmutable": "^0.34.0",
+    "unmutable": "^0.34.1",
     "url-search-params": "^0.9.0"
   },
   "main": "lib/index.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6010,9 +6010,9 @@ universalify@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.1.tgz#fa71badd4437af4c148841e3b3b165f9e9e590b7"
 
-unmutable@^0.34.0:
-  version "0.34.0"
-  resolved "https://registry.yarnpkg.com/unmutable/-/unmutable-0.34.0.tgz#512ad3f5286215cab8ce554741d42c2ca8822a70"
+unmutable@^0.34.1:
+  version "0.34.1"
+  resolved "https://registry.yarnpkg.com/unmutable/-/unmutable-0.34.1.tgz#e417973cf11540756565fb15027402275401b311"
   dependencies:
     fast-deep-equal "^1.0.0"
     is-plain-object "^2.0.4"


### PR DESCRIPTION
- PropChangeHock can now `getIn` recognise inherited properties in any of its `path` strings